### PR TITLE
feat: add concurrent request limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- API keys can now set an in-memory concurrent-request limit with stream-safe,
+  process-monitored leases across in-process, ReqLLM, SafeRPC, and HTTP
+  generation or moderation calls.
+
 ## 0.1.1 - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ curl http://127.0.0.1:4000/v1/chat/completions \
 - **Connect your applications once.** Point any OpenAI-compatible client at LLMProxy, use the Anthropic Messages API, or call it directly from Elixir. Stop duplicating provider adapters, authentication, retries, and usage tracking in every product.
 - **Change providers without changing clients.** Applications request a public name such as `fast`; you can move it from OpenAI to Anthropic, OpenRouter, or a private endpoint by changing gateway configuration instead of application code.
 - **Keep working when a provider does not.** Route across multiple models, providers, regions, or credentials. Timeouts, retries, health-aware fallbacks, circuit breakers, and load-balancing strategies keep individual failures away from your users.
-- **Control spend before the invoice arrives.** Issue keys per application, customer, or team; restrict which models they can call; and enforce token, request, cache, and dollar budgets. See usage and estimated cost in one place.
+- **Control spend before the invoice arrives.** Issue keys per application, customer, or team; restrict which models they can call; and enforce concurrent-request, token, request, cache, and dollar limits. See usage and estimated cost in one place.
 - **Stop spreading provider keys across services.** Store upstream credentials in the gateway, rotate or pool them centrally, and give applications LLMProxy keys with only the access they need.
 - **Self-host without adding a Python control plane.** Run the bundled OTP service as a LiteLLM-style gateway, or embed the same capabilities directly in an Elixir/Phoenix release. Your prompts, traces, credentials, and operational data remain under your control.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Out of scope for the core package:
 ### Governance
 
 - Add per-model and future actor/team budget scopes without weakening the existing API-key boundary.
-- Add RPM, TPM, and concurrent-request limits to the composable limit model.
+- Add RPM and TPM limits to the composable limit model.
 - Improve cache-hit accounting and policy visibility.
 
 ### Routing

--- a/guides/features/governance-and-observability.md
+++ b/guides/features/governance-and-observability.md
@@ -39,9 +39,10 @@ Set `allowed_models` on an API key to constrain it to public catalog names:
 
 Clients never need direct access to upstream provider names or credentials. Catalog aliases are the policy boundary.
 
-## Budget limits
+## Composable limits
 
-Composable limits operate over stored usage windows:
+Most composable limits operate over stored usage windows. A concurrent-request
+limit is an in-memory admission limit and does not use a window:
 
 ```elixir
 %{
@@ -49,7 +50,8 @@ Composable limits operate over stored usage windows:
     LLMProxy.Limit.cost(:day, 10.00),
     LLMProxy.Limit.requests(:minute, 60),
     LLMProxy.Limit.input_tokens(:four_hours, 100_000),
-    LLMProxy.Limit.output_tokens(:week, 500_000)
+    LLMProxy.Limit.output_tokens(:week, 500_000),
+    LLMProxy.Limit.concurrent_requests(8)
   ]
 }
 ```
@@ -62,6 +64,7 @@ Supported metrics:
 - `:output_tokens`
 - `:cache_read_tokens`
 - `:cache_write_tokens`
+- `:concurrent_requests`
 
 Supported windows:
 
@@ -71,6 +74,19 @@ Supported windows:
 - `:day`
 - `:week`
 - `:month`
+
+`concurrent_requests` has no window. It limits active generation and moderation
+calls for one API key in one LLMProxy runtime instance. A rejected call receives
+HTTP 429 and `Retry-After: 1` on HTTP routes. A stream keeps its slot until it
+completes, halts, raises, or its consumer process exits.
+
+Admission and release do not query storage. Aggregate content-free counters are
+available from `LLMProxy.ConcurrencyLimiter.status/0` and the standalone health
+response. `LLMProxy.ConcurrencyLimiter.status/1` returns the active count for a
+key without a storage query.
+
+When several LLMProxy instances serve the same keys, the limit applies to each
+instance. Set the per-instance value to match the total capacity plan.
 
 Stored maps may use equivalent strings such as `"cost_usd"`, `"4h"`, `"24h"`, `"7d"`, and `"30d"`.
 

--- a/guides/internals/architecture.md
+++ b/guides/internals/architecture.md
@@ -17,6 +17,8 @@ LLMProxy.chat/2    ReqLLM provider    HTTP routes    SafeRPC
                                   │
                        before-request guardrails
                                   │
+                  per-key concurrent admission
+                                  │
                       cache key and catalog plan
                                   │
                   timeout / retry / fallback / circuit
@@ -50,6 +52,7 @@ LLMProxy
 ├── TokenPool                credential selection and cooldown state
 ├── Cache                    adapter, deterministic key, and policy
 ├── GuardrailPipeline        request, response, and stream policy hooks
+├── ConcurrencyLimiter       monitored per-key request and stream leases
 ├── Accounting               usage, spend, traces, and message recording
 ├── Telemetry                telemetry events and OpenTelemetry spans
 ├── Stream                   normalized events, SSE writing, and heartbeats

--- a/guides/introduction/library-mode.md
+++ b/guides/introduction/library-mode.md
@@ -89,7 +89,9 @@ Pass either:
 - `:api_key` with a raw LLMProxy key or an existing API-key schema/map; or
 - `:actor` with `%LLMProxy.Actor{}`.
 
-The key determines model access, quotas, budget limits, attribution, and stored usage. The master key is accepted for bootstrap and operator calls but should not be distributed to ordinary clients.
+The key determines model access, quotas, budget and concurrent-request limits,
+attribution, and stored usage. The master key is accepted for bootstrap and
+operator calls but should not be distributed to ordinary clients.
 
 ## ReqLLM provider
 

--- a/guides/reference/http-api.cheatmd
+++ b/guides/reference/http-api.cheatmd
@@ -24,7 +24,8 @@ Model listing and health are public.
 GET /health
 ```
 
-Standalone router only. Reports version, readiness, drain state, serving state, and active request/stream/agent counts.
+Standalone router only. Reports version, readiness, drain state, serving state,
+active request/stream/agent counts, and aggregate concurrent-admission counters.
 
 ### Models
 
@@ -139,7 +140,12 @@ The same identifier links HTTP responses, usage, messages, traces, telemetry, an
 
 Authenticated JSON routes enforce the configured body limit after authentication and quota checks. Default: 32 MB.
 
-Requests above the limit receive HTTP 413. Malformed protocol requests receive structured 400 errors. Authentication failures receive 401, model-access or policy failures receive 403, unknown models receive 404, and upstream errors preserve a canonical provider status when available.
+Requests above the body limit receive HTTP 413. Malformed protocol requests
+receive structured 400 errors. Authentication failures receive 401,
+model-access or policy failures receive 403, unknown models receive 404, and
+upstream errors preserve a canonical provider status when available. Calls
+rejected by a per-key concurrent-request limit receive HTTP 429 and
+`Retry-After: 1`.
 
 ## Phoenix Mounts
 

--- a/lib/llm_proxy/application.ex
+++ b/lib/llm_proxy/application.ex
@@ -27,6 +27,7 @@ defmodule LLMProxy.Application do
       storage_children() ++
         [
           LLMProxy.Drain,
+          LLMProxy.ConcurrencyLimiter,
           LLMProxy.Providers.CircuitBreaker,
           LLMProxy.Providers.Routing.RoundRobin,
           LLMProxy.TokenPool.Server

--- a/lib/llm_proxy/concurrency_limiter.ex
+++ b/lib/llm_proxy/concurrency_limiter.ex
@@ -1,0 +1,136 @@
+defmodule LLMProxy.ConcurrencyLimiter do
+  @moduledoc """
+  In-memory concurrent-request admission for LLMProxy API keys.
+
+  Add `LLMProxy.Limit.concurrent_requests/1` to a key's `budget_limits` to
+  enable the gate. Admission and release do not query storage. Limits apply to
+  one LLMProxy runtime instance; deployments with multiple instances must size
+  each instance accordingly.
+
+  A lease follows a stream into the process that consumes it. The lease is
+  released when the request or stream ends, when stream enumeration halts, or
+  when the process that owns the lease exits.
+  """
+
+  alias LLMProxy.ConcurrencyLimiter.{Lease, Server}
+
+  defmodule Lease do
+    @moduledoc false
+
+    @enforce_keys [:ref, :key_id, :limit]
+    defstruct [:ref, :key_id, :limit]
+
+    @type t :: %__MODULE__{
+            ref: reference(),
+            key_id: String.t(),
+            limit: non_neg_integer()
+          }
+  end
+
+  defmodule LeaseExpiredError do
+    @moduledoc false
+    defexception message: "Concurrent request lease is no longer active"
+  end
+
+  @type lease :: Lease.t() | :unlimited
+  @type status :: %{
+          active: non_neg_integer(),
+          admitted: non_neg_integer(),
+          rejected: non_neg_integer(),
+          released: non_neg_integer()
+        }
+
+  @error_message "Concurrent request limit exceeded"
+  @retry_after_seconds 1
+
+  @doc "Returns the stable public message for an admission refusal."
+  @spec error_message() :: String.t()
+  def error_message, do: @error_message
+
+  @doc "Returns the retry delay advertised by HTTP admission refusals."
+  @spec retry_after_seconds() :: pos_integer()
+  def retry_after_seconds, do: @retry_after_seconds
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts), do: Supervisor.child_spec({Server, opts}, id: __MODULE__)
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []), do: Server.start_link(opts)
+
+  @doc """
+  Tries to acquire one request lease for an API key.
+
+  Keys without a concurrent-request limit receive an unlimited no-op lease.
+  """
+  @spec acquire(map(), pid()) ::
+          {:ok, lease()} | {:error, {:limit_exceeded, non_neg_integer()}}
+  def acquire(api_key, owner \\ self())
+
+  def acquire(%{id: key_id} = api_key, owner) when is_pid(owner) do
+    case LLMProxy.Limit.concurrent_request_limit(api_key) do
+      nil -> {:ok, :unlimited}
+      limit -> Server.acquire(to_string(key_id), limit, owner)
+    end
+  end
+
+  @doc "Runs a non-streaming request while holding its configured lease."
+  @spec run(map(), (-> result)) ::
+          result | {:error, {:limit_exceeded, non_neg_integer()}}
+        when result: term()
+  def run(api_key, fun) when is_function(fun, 0) do
+    case acquire(api_key) do
+      {:ok, lease} ->
+        try do
+          fun.()
+        after
+          release(lease)
+        end
+
+      {:error, {:limit_exceeded, _limit}} = error ->
+        error
+    end
+  end
+
+  @doc "Releases a request lease. Repeated release calls are safe."
+  @spec release(lease()) :: :ok
+  def release(:unlimited), do: :ok
+  def release(%Lease{} = lease), do: Server.release(lease)
+
+  @doc """
+  Wraps a stream so its lease follows the consumer and is always released.
+  """
+  @spec wrap_stream(Enumerable.t(), lease()) :: Enumerable.t()
+  def wrap_stream(stream, :unlimited), do: stream
+
+  def wrap_stream(stream, %Lease{} = lease) do
+    Stream.transform(
+      stream,
+      fn -> transfer!(lease) end,
+      fn item, active_lease -> {[item], active_lease} end,
+      fn active_lease -> {[], active_lease} end,
+      &release/1
+    )
+  end
+
+  @doc "Returns aggregate content-free counters for limited requests."
+  @spec status() :: status()
+  def status, do: Server.status()
+
+  @doc "Returns the current active count and configured limit for one key."
+  @spec status(map() | String.t()) :: map()
+  def status(%{id: key_id} = api_key) do
+    key_id
+    |> to_string()
+    |> Server.status()
+    |> Map.put(:limit, LLMProxy.Limit.concurrent_request_limit(api_key))
+  end
+
+  def status(key_id) when is_binary(key_id), do: Server.status(key_id)
+
+  defp transfer!(lease) do
+    case Server.transfer(lease, self()) do
+      :ok -> lease
+      {:error, :released} -> raise LeaseExpiredError
+    end
+  end
+end

--- a/lib/llm_proxy/concurrency_limiter/server.ex
+++ b/lib/llm_proxy/concurrency_limiter/server.ex
@@ -1,0 +1,143 @@
+defmodule LLMProxy.ConcurrencyLimiter.Server do
+  @moduledoc false
+
+  use GenServer
+
+  alias LLMProxy.ConcurrencyLimiter.Lease
+
+  defstruct leases: %{},
+            monitors: %{},
+            active_by_key: %{},
+            admitted: 0,
+            rejected: 0,
+            released: 0
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, %__MODULE__{}, Keyword.put_new(opts, :name, __MODULE__))
+  end
+
+  @spec acquire(String.t(), non_neg_integer(), pid()) ::
+          {:ok, Lease.t()} | {:error, {:limit_exceeded, non_neg_integer()}}
+  def acquire(key_id, limit, owner) do
+    GenServer.call(__MODULE__, {:acquire, key_id, limit, owner})
+  end
+
+  @spec release(Lease.t()) :: :ok
+  def release(%Lease{ref: ref}), do: GenServer.call(__MODULE__, {:release, ref})
+
+  @spec transfer(Lease.t(), pid()) :: :ok | {:error, :released}
+  def transfer(%Lease{ref: ref}, owner) do
+    GenServer.call(__MODULE__, {:transfer, ref, owner})
+  end
+
+  @spec status() :: map()
+  def status, do: GenServer.call(__MODULE__, :status)
+
+  @spec status(String.t()) :: map()
+  def status(key_id), do: GenServer.call(__MODULE__, {:status, key_id})
+
+  @impl true
+  def init(%__MODULE__{} = state), do: {:ok, state}
+
+  @impl true
+  def handle_call({:acquire, key_id, limit, owner}, _from, state) do
+    active = Map.get(state.active_by_key, key_id, 0)
+
+    if active >= limit do
+      {:reply, {:error, {:limit_exceeded, limit}}, %{state | rejected: state.rejected + 1}}
+    else
+      ref = make_ref()
+      monitor = Process.monitor(owner)
+
+      lease = %Lease{ref: ref, key_id: key_id, limit: limit}
+      lease_state = %{key_id: key_id, owner: owner, monitor: monitor}
+
+      state = %{
+        state
+        | leases: Map.put(state.leases, ref, lease_state),
+          monitors: Map.put(state.monitors, monitor, ref),
+          active_by_key: Map.put(state.active_by_key, key_id, active + 1),
+          admitted: state.admitted + 1
+      }
+
+      {:reply, {:ok, lease}, state}
+    end
+  end
+
+  def handle_call({:release, ref}, _from, state) do
+    {:reply, :ok, remove_lease(state, ref, true)}
+  end
+
+  def handle_call({:transfer, ref, owner}, _from, state) do
+    case Map.fetch(state.leases, ref) do
+      {:ok, %{owner: ^owner}} ->
+        {:reply, :ok, state}
+
+      {:ok, lease_state} ->
+        Process.demonitor(lease_state.monitor, [:flush])
+        monitor = Process.monitor(owner)
+
+        state = %{
+          state
+          | leases: Map.put(state.leases, ref, %{lease_state | owner: owner, monitor: monitor}),
+            monitors:
+              state.monitors
+              |> Map.delete(lease_state.monitor)
+              |> Map.put(monitor, ref)
+        }
+
+        {:reply, :ok, state}
+
+      :error ->
+        {:reply, {:error, :released}, state}
+    end
+  end
+
+  def handle_call(:status, _from, state) do
+    {:reply,
+     %{
+       active: map_size(state.leases),
+       admitted: state.admitted,
+       rejected: state.rejected,
+       released: state.released
+     }, state}
+  end
+
+  def handle_call({:status, key_id}, _from, state) do
+    {:reply, %{key_id: key_id, active: Map.get(state.active_by_key, key_id, 0)}, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, monitor, :process, _pid, _reason}, state) do
+    case Map.fetch(state.monitors, monitor) do
+      {:ok, ref} -> {:noreply, remove_lease(state, ref, false)}
+      :error -> {:noreply, state}
+    end
+  end
+
+  defp remove_lease(state, ref, demonitor?) do
+    case Map.pop(state.leases, ref) do
+      {nil, _leases} ->
+        state
+
+      {lease, leases} ->
+        if demonitor?, do: Process.demonitor(lease.monitor, [:flush])
+
+        %{
+          state
+          | leases: leases,
+            monitors: Map.delete(state.monitors, lease.monitor),
+            active_by_key: decrement_active(state.active_by_key, lease.key_id),
+            released: state.released + 1
+        }
+    end
+  end
+
+  defp decrement_active(active_by_key, key_id) do
+    case Map.get(active_by_key, key_id, 0) do
+      count when count <= 1 -> Map.delete(active_by_key, key_id)
+      count -> Map.put(active_by_key, key_id, count - 1)
+    end
+  end
+end

--- a/lib/llm_proxy/http/error_response.ex
+++ b/lib/llm_proxy/http/error_response.ex
@@ -7,7 +7,7 @@ defmodule LLMProxy.HTTP.ErrorResponse do
   Anthropic Messages envelope when the request path targets that API.
   """
 
-  alias LLMProxy.HTTP
+  alias LLMProxy.{ConcurrencyLimiter, HTTP}
 
   @max_message_length 2_000
 
@@ -24,6 +24,16 @@ defmodule LLMProxy.HTTP.ErrorResponse do
   @spec send_openai(Plug.Conn.t(), pos_integer(), String.t(), term()) :: Plug.Conn.t()
   def send_openai(conn, status, code, message) do
     HTTP.send_json(conn, status, %{"error" => openai_error(status, code, message)})
+  end
+
+  @spec send_concurrency_limit_openai(Plug.Conn.t()) :: Plug.Conn.t()
+  def send_concurrency_limit_openai(conn) do
+    conn
+    |> Plug.Conn.put_resp_header(
+      "retry-after",
+      Integer.to_string(ConcurrencyLimiter.retry_after_seconds())
+    )
+    |> send_openai(429, "rate_limit_error", ConcurrencyLimiter.error_message())
   end
 
   @spec send_openai(Plug.Conn.t(), pos_integer(), map()) :: Plug.Conn.t()

--- a/lib/llm_proxy/http/router.ex
+++ b/lib/llm_proxy/http/router.ex
@@ -26,7 +26,8 @@ defmodule LLMProxy.HTTP.Router do
       ready: drain.ready,
       draining: drain.draining,
       serving: drain.serving,
-      active: drain.active
+      active: drain.active,
+      concurrency: LLMProxy.ConcurrencyLimiter.status()
     })
   end
 

--- a/lib/llm_proxy/http/routes/chat.ex
+++ b/lib/llm_proxy/http/routes/chat.ex
@@ -113,6 +113,10 @@ defmodule LLMProxy.HTTP.Routes.Chat do
     ErrorResponse.send_openai(conn, 403, "permission_error", message)
   end
 
+  defp handle_provider_error(conn, {:concurrency_limit, _limit}) do
+    ErrorResponse.send_concurrency_limit_openai(conn)
+  end
+
   defp finish_stream(conn, %Result{kind: :stream} = result, trace_id) do
     from_protocol = provider_protocol(result.provider)
     telemetry = Telemetry.stream_context(result.provider.name(), result.model, trace_id)

--- a/lib/llm_proxy/http/routes/moderation_endpoint.ex
+++ b/lib/llm_proxy/http/routes/moderation_endpoint.ex
@@ -7,6 +7,7 @@ defmodule LLMProxy.HTTP.Routes.ModerationEndpoint do
 
   require Logger
 
+  alias LLMProxy.ConcurrencyLimiter
   alias LLMProxy.HTTP
   alias LLMProxy.HTTP.ErrorResponse
   alias LLMProxy.Plugs.{Auth, JSONBodyParser, QuotaCheck}
@@ -64,6 +65,15 @@ defmodule LLMProxy.HTTP.Routes.ModerationEndpoint do
   end
 
   defp moderate(conn, api_key, %CreateRequest{} = attrs, trace_id) do
+    case ConcurrencyLimiter.run(api_key, fn ->
+           run_moderation(conn, api_key, attrs, trace_id)
+         end) do
+      {:error, {:limit_exceeded, _limit}} -> ErrorResponse.send_concurrency_limit_openai(conn)
+      result -> result
+    end
+  end
+
+  defp run_moderation(conn, api_key, %CreateRequest{} = attrs, trace_id) do
     Logger.info("Moderation from #{api_key.name} model=#{attrs.model}")
 
     case TokenPool.pick_token_by_kind("openai", "api-key", api_key.id) do

--- a/lib/llm_proxy/http/routes/passthrough.ex
+++ b/lib/llm_proxy/http/routes/passthrough.ex
@@ -8,6 +8,7 @@ defmodule LLMProxy.HTTP.Routes.Passthrough do
 
   require Logger
 
+  alias LLMProxy.ConcurrencyLimiter
   alias LLMProxy.HTTP.ErrorResponse
   alias LLMProxy.Providers.Result
 
@@ -113,6 +114,14 @@ defmodule LLMProxy.HTTP.Routes.Passthrough do
       {:guardrail, reason} ->
         message = ErrorResponse.safe_message(reason, "Request blocked by guardrail")
         handler.send_error.(conn, 403, "permission_error", message)
+
+      {:concurrency_limit, _limit} ->
+        conn
+        |> Plug.Conn.put_resp_header(
+          "retry-after",
+          Integer.to_string(ConcurrencyLimiter.retry_after_seconds())
+        )
+        |> handler.send_error.(429, "rate_limit_error", ConcurrencyLimiter.error_message())
     end
   end
 

--- a/lib/llm_proxy/limit.ex
+++ b/lib/llm_proxy/limit.ex
@@ -1,6 +1,6 @@
 defmodule LLMProxy.Limit do
   @moduledoc """
-  Usage limit for API keys.
+  Composable usage and runtime limits for API keys.
   """
 
   import Ecto.Query
@@ -14,7 +14,8 @@ defmodule LLMProxy.Limit do
     :output_tokens,
     :cache_read_tokens,
     :cache_write_tokens,
-    :requests
+    :requests,
+    :concurrent_requests
   ]
   @windows [:minute, :hour, :four_hours, :day, :week, :month]
 
@@ -24,7 +25,8 @@ defmodule LLMProxy.Limit do
     "output_tokens" => :output_tokens,
     "cache_read_tokens" => :cache_read_tokens,
     "cache_write_tokens" => :cache_write_tokens,
-    "requests" => :requests
+    "requests" => :requests,
+    "concurrent_requests" => :concurrent_requests
   }
 
   @window_aliases %{
@@ -56,13 +58,16 @@ defmodule LLMProxy.Limit do
 
   @type metric :: unquote(Enum.reduce(@metrics, &{:|, [], [&1, &2]}))
   @type window :: unquote(Enum.reduce(@windows, &{:|, [], [&1, &2]}))
-  @type t :: %__MODULE__{metric: metric(), window: window(), max: number()}
+  @type t :: %__MODULE__{metric: metric(), window: window() | nil, max: number()}
 
   @spec cost(window(), number()) :: t()
   def cost(window, max), do: new(:cost_usd, window, max)
 
   @spec requests(window(), non_neg_integer()) :: t()
   def requests(window, max), do: new(:requests, window, max)
+
+  @spec concurrent_requests(non_neg_integer()) :: t()
+  def concurrent_requests(max), do: new(:concurrent_requests, nil, max)
 
   @spec input_tokens(window(), non_neg_integer()) :: t()
   def input_tokens(window, max), do: new(:input_tokens, window, max)
@@ -76,9 +81,14 @@ defmodule LLMProxy.Limit do
   @spec cache_write_tokens(window(), non_neg_integer()) :: t()
   def cache_write_tokens(window, max), do: new(:cache_write_tokens, window, max)
 
-  @spec new(metric(), window(), number()) :: t()
+  @spec new(metric(), window() | nil, number()) :: t()
+  def new(:concurrent_requests, nil, max) when is_integer(max) and max >= 0 do
+    %__MODULE__{metric: :concurrent_requests, window: nil, max: max}
+  end
+
   def new(metric, window, max)
-      when metric in @metrics and window in @windows and is_number(max) and max >= 0 do
+      when metric in @metrics and metric != :concurrent_requests and window in @windows and
+             is_number(max) and max >= 0 do
     %__MODULE__{metric: metric, window: window, max: max}
   end
 
@@ -101,6 +111,28 @@ defmodule LLMProxy.Limit do
   end
 
   def check(_key), do: :ok
+
+  @doc """
+  Returns the most restrictive concurrent-request limit for an API key.
+
+  Concurrent limits do not use a stored usage window. Runtime admission uses
+  this value without a storage query.
+  """
+  @spec concurrent_request_limit(map()) :: non_neg_integer() | nil
+  def concurrent_request_limit(%{budget_limits: limits}) do
+    limits =
+      limits
+      |> normalize_all()
+      |> Enum.filter(&(&1.metric == :concurrent_requests))
+      |> Enum.map(& &1.max)
+
+    case limits do
+      [] -> nil
+      limits -> Enum.min(limits)
+    end
+  end
+
+  def concurrent_request_limit(_key), do: nil
 
   @spec normalize(term()) :: {:ok, [t()]} | {:error, String.t()}
   def normalize(nil), do: {:ok, []}
@@ -131,17 +163,33 @@ defmodule LLMProxy.Limit do
     end
   end
 
-  defp normalize_limit(%__MODULE__{} = limit), do: {:ok, limit}
+  defp normalize_limit(%__MODULE__{} = limit) do
+    limit
+    |> Map.from_struct()
+    |> normalize_limit()
+  end
 
   defp normalize_limit(%{} = limit) do
-    with {:ok, metric} <- normalize_metric(get(limit, :metric, "metric")),
-         {:ok, window} <- normalize_window(get(limit, :window, "window")),
-         {:ok, max} <- normalize_max(get(limit, :max, "max")) do
-      {:ok, new(metric, window, max)}
+    with {:ok, metric} <- normalize_metric(get(limit, :metric, "metric")) do
+      normalize_limit(metric, limit)
     end
   end
 
   defp normalize_limit(_limit), do: {:error, "limit must be a map"}
+
+  defp normalize_limit(:concurrent_requests, limit) do
+    with :ok <- normalize_concurrent_window(get(limit, :window, "window")),
+         {:ok, max} <- normalize_concurrent_max(get(limit, :max, "max")) do
+      {:ok, new(:concurrent_requests, nil, max)}
+    end
+  end
+
+  defp normalize_limit(metric, limit) do
+    with {:ok, window} <- normalize_window(get(limit, :window, "window")),
+         {:ok, max} <- normalize_max(get(limit, :max, "max")) do
+      {:ok, new(metric, window, max)}
+    end
+  end
 
   defp normalize_metric(metric) when is_atom(metric) do
     if metric in metrics(), do: {:ok, metric}, else: {:error, "invalid metric"}
@@ -171,6 +219,16 @@ defmodule LLMProxy.Limit do
 
   defp normalize_max(max) when is_number(max) and max >= 0, do: {:ok, max}
   defp normalize_max(_max), do: {:error, "invalid max"}
+
+  defp normalize_concurrent_window(nil), do: :ok
+
+  defp normalize_concurrent_window(_window),
+    do: {:error, "concurrent limit must not use a window"}
+
+  defp normalize_concurrent_max(max) when is_integer(max) and max >= 0, do: {:ok, max}
+  defp normalize_concurrent_max(_max), do: {:error, "invalid concurrent max"}
+
+  defp check_limit(_key_id, %__MODULE__{metric: :concurrent_requests}), do: :ok
 
   defp check_limit(key_id, %__MODULE__{} = limit) do
     usage = usage(key_id, limit.metric, Map.fetch!(@window_ms, limit.window))

--- a/lib/llm_proxy/provider.ex
+++ b/lib/llm_proxy/provider.ex
@@ -15,6 +15,7 @@ defmodule LLMProxy.Provider do
   alias LLMProxy.Accounting.UsageTracking
   alias LLMProxy.Actor
   alias LLMProxy.Cache.Runtime, as: CacheRuntime
+  alias LLMProxy.ConcurrencyLimiter
   alias LLMProxy.GuardrailPipeline
   alias LLMProxy.HTTP.ErrorResponse
   alias LLMProxy.Protocol.Request
@@ -33,6 +34,7 @@ defmodule LLMProxy.Provider do
           | {:not_found, String.t()}
           | {:missing_api_key, term()}
           | {:invalid_api_key, String.t()}
+          | {:concurrency_limit, non_neg_integer()}
           | {:guardrail, term()}
           | {:provider, Result.t()}
 
@@ -48,19 +50,9 @@ defmodule LLMProxy.Provider do
          :ok <- check_model_access(api_key, request.model),
          {:ok, [%Attempt{provider: provider, model: upstream_model} | _] = attempts} <-
            Registry.resolve_attempts(request.model) do
-      Logger.debug(
-        "Provider request from #{actor.name || actor.id} model=#{request.model} provider=#{provider.name()}"
-      )
-
-      opts =
-        put_message_log_id(
-          opts,
-          UsageTracking.log_user_message(api_key, request.model, to_string(route), fn ->
-            Request.user_text(request)
-          end)
-        )
-
-      call_provider(provider, request, actor, api_key, upstream_model, attempts, route, opts)
+      with_request_lease(api_key, fn ->
+        execute_call(provider, request, actor, api_key, upstream_model, attempts, route, opts)
+      end)
     else
       :error -> {:error, {:not_found, "Model '#{request.model}' not found"}}
       {:error, {:missing_api_key, _}} = error -> error
@@ -83,19 +75,9 @@ defmodule LLMProxy.Provider do
          :ok <- check_model_access(api_key, request.model),
          {:ok, [%Attempt{provider: provider, model: upstream_model} | _] = attempts} <-
            Registry.resolve_attempts(request.model) do
-      Logger.debug(
-        "Provider stream from #{actor.name || actor.id} model=#{request.model} provider=#{provider.name()}"
-      )
-
-      opts =
-        put_message_log_id(
-          opts,
-          UsageTracking.log_user_message(api_key, request.model, to_string(route), fn ->
-            Request.user_text(request)
-          end)
-        )
-
-      stream_provider(provider, request, actor, api_key, upstream_model, attempts, route, opts)
+      with_stream_lease(api_key, fn ->
+        execute_stream(provider, request, actor, api_key, upstream_model, attempts, route, opts)
+      end)
     else
       :error -> {:error, {:not_found, "Model '#{request.model}' not found"}}
       {:error, {:missing_api_key, _}} = error -> error
@@ -264,6 +246,85 @@ defmodule LLMProxy.Provider do
   defp check_model_access(%{id: "master"}, _model), do: :ok
   defp check_model_access(api_key, model), do: LLMProxy.Storage.check_model_access(api_key, model)
 
+  defp with_request_lease(api_key, fun) do
+    case ConcurrencyLimiter.run(api_key, fun) do
+      {:error, {:limit_exceeded, limit}} ->
+        {:error, {:concurrency_limit, limit}}
+
+      result ->
+        result
+    end
+  end
+
+  defp with_stream_lease(api_key, fun) do
+    case ConcurrencyLimiter.acquire(api_key) do
+      {:ok, lease} -> retain_stream_lease(fun, lease)
+      {:error, {:limit_exceeded, limit}} -> {:error, {:concurrency_limit, limit}}
+    end
+  end
+
+  defp retain_stream_lease(fun, lease) do
+    case fun.() do
+      {:ok, %Result{kind: :stream, stream: stream} = result} ->
+        {:ok, %{result | stream: ConcurrencyLimiter.wrap_stream(stream, lease)}}
+
+      result ->
+        ConcurrencyLimiter.release(lease)
+        result
+    end
+  catch
+    kind, reason ->
+      ConcurrencyLimiter.release(lease)
+      :erlang.raise(kind, reason, __STACKTRACE__)
+  end
+
+  defp with_native_lease(:stream_native, api_key, fun), do: with_stream_lease(api_key, fun)
+  defp with_native_lease(:call_native, api_key, fun), do: with_request_lease(api_key, fun)
+
+  defp execute_call(provider, request, actor, api_key, upstream_model, attempts, route, opts) do
+    Logger.debug(
+      "Provider request from #{actor.name || actor.id} model=#{request.model} provider=#{provider.name()}"
+    )
+
+    opts = log_user_message(opts, api_key, request, route)
+    call_provider(provider, request, actor, api_key, upstream_model, attempts, route, opts)
+  end
+
+  defp execute_stream(provider, request, actor, api_key, upstream_model, attempts, route, opts) do
+    Logger.debug(
+      "Provider stream from #{actor.name || actor.id} model=#{request.model} provider=#{provider.name()}"
+    )
+
+    opts = log_user_message(opts, api_key, request, route)
+    stream_provider(provider, request, actor, api_key, upstream_model, attempts, route, opts)
+  end
+
+  defp execute_native_call(
+         {provider, upstream_model, attempts},
+         request,
+         actor,
+         api_key,
+         route,
+         function,
+         opts
+       ) do
+    Logger.debug(
+      "Provider native #{function} from #{actor.name || actor.id} model=#{request.model} provider=#{provider.name()}"
+    )
+
+    opts = log_user_message(opts, api_key, request, route)
+    call_native_provider(provider, upstream_model, attempts, request, api_key, function, opts)
+  end
+
+  defp log_user_message(opts, api_key, request, route) do
+    put_message_log_id(
+      opts,
+      UsageTracking.log_user_message(api_key, request.model, to_string(route), fn ->
+        Request.user_text(request)
+      end)
+    )
+  end
+
   defp put_message_log_id(opts, {:ok, %{id: id}}), do: Keyword.put(opts, :message_log_id, id)
   defp put_message_log_id(opts, _result), do: opts
 
@@ -333,19 +394,17 @@ defmodule LLMProxy.Provider do
          :ok <- check_model_access(api_key, request.model),
          {:ok, [%Attempt{provider: provider, model: upstream_model} | _] = attempts} <-
            Registry.resolve_attempts(request.model) do
-      Logger.debug(
-        "Provider native #{function} from #{actor.name || actor.id} model=#{request.model} provider=#{provider.name()}"
-      )
-
-      opts =
-        put_message_log_id(
-          opts,
-          UsageTracking.log_user_message(api_key, request.model, to_string(route), fn ->
-            Request.user_text(request)
-          end)
+      with_native_lease(function, api_key, fn ->
+        execute_native_call(
+          {provider, upstream_model, attempts},
+          request,
+          actor,
+          api_key,
+          route,
+          function,
+          opts
         )
-
-      call_native_provider(provider, upstream_model, attempts, request, api_key, function, opts)
+      end)
     else
       :error -> {:error, {:not_found, "Model '#{request.model}' not found"}}
       {:error, {:missing_api_key, _}} = error -> error
@@ -670,6 +729,14 @@ defmodule LLMProxy.Provider do
         ErrorResponse.safe_message(reason, "Request blocked by guardrail")
       )
 
+  defp req_llm_error({:concurrency_limit, _limit}, status),
+    do:
+      ErrorResponse.openai_error(
+        status,
+        "rate_limit_error",
+        ConcurrencyLimiter.error_message()
+      )
+
   defp req_llm_error(_reason, status),
     do: ErrorResponse.openai_error(status, "internal_error", "LLMProxy request failed")
 
@@ -679,6 +746,7 @@ defmodule LLMProxy.Provider do
   defp error_status({:missing_api_key, _}), do: 401
   defp error_status({:invalid_api_key, _}), do: 401
   defp error_status({:guardrail, _}), do: 403
+  defp error_status({:concurrency_limit, _limit}), do: 429
   defp error_status({:provider, %{status: status}}) when is_integer(status), do: status
   defp error_status(_reason), do: 500
 

--- a/mix.exs
+++ b/mix.exs
@@ -122,6 +122,7 @@ defmodule LLMProxy.MixProject do
           LLMProxy.Phoenix.Router
         ],
         Operations: [
+          LLMProxy.ConcurrencyLimiter,
           LLMProxy.Drain,
           LLMProxy.Ops,
           LLMProxy.ReleaseTasks,

--- a/test/llm_proxy/concurrency_limiter_test.exs
+++ b/test/llm_proxy/concurrency_limiter_test.exs
@@ -1,0 +1,154 @@
+defmodule LLMProxy.ConcurrencyLimiterTest do
+  use ExUnit.Case, async: true
+
+  alias LLMProxy.ConcurrencyLimiter
+  alias LLMProxy.Limit
+
+  test "normalizes concurrent limits without a usage window" do
+    assert %Limit{metric: :concurrent_requests, window: nil, max: 3} =
+             Limit.concurrent_requests(3)
+
+    assert {:ok, [%Limit{metric: :concurrent_requests, window: nil, max: 2}]} =
+             Limit.normalize([%{"metric" => "concurrent_requests", "max" => 2}])
+
+    refute Limit.valid?([
+             %{
+               "metric" => "concurrent_requests",
+               "window" => "minute",
+               "max" => 2
+             }
+           ])
+
+    refute Limit.valid?([%{"metric" => "concurrent_requests", "max" => 1.5}])
+
+    assert Limit.concurrent_request_limit(%{
+             budget_limits: [Limit.concurrent_requests(4), Limit.concurrent_requests(2)]
+           }) == 2
+
+    assert :ok =
+             Limit.check(%{
+               id: "no-storage-query",
+               budget_limits: [Limit.concurrent_requests(1)]
+             })
+  end
+
+  test "admits up to the per-key limit and exposes safe counters" do
+    key = limited_key(1)
+    before = ConcurrencyLimiter.status()
+
+    assert {:ok, lease} = ConcurrencyLimiter.acquire(key)
+    assert %{active: 1, limit: 1} = ConcurrencyLimiter.status(key)
+    assert {:error, {:limit_exceeded, 1}} = ConcurrencyLimiter.acquire(key)
+
+    assert :ok = ConcurrencyLimiter.release(lease)
+    assert :ok = ConcurrencyLimiter.release(lease)
+    assert %{active: 0, limit: 1} = ConcurrencyLimiter.status(key)
+
+    after_status = ConcurrencyLimiter.status()
+    assert after_status.admitted >= before.admitted + 1
+    assert after_status.rejected >= before.rejected + 1
+    assert after_status.released >= before.released + 1
+  end
+
+  test "releases a lease when its owner exits" do
+    key = limited_key(1)
+    parent = self()
+
+    {pid, monitor} =
+      spawn_monitor(fn ->
+        {:ok, _lease} = ConcurrencyLimiter.acquire(key)
+        send(parent, :lease_acquired)
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive :lease_acquired, 1_000
+    assert %{active: 1} = ConcurrencyLimiter.status(key)
+
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^monitor, :process, ^pid, :killed}, 1_000
+    assert_eventually(fn -> ConcurrencyLimiter.status(key).active == 0 end)
+  end
+
+  test "releases stream leases after completion, early halt, and exception" do
+    key = limited_key(1)
+
+    assert {:ok, completed_lease} = ConcurrencyLimiter.acquire(key)
+
+    assert [1, 2] ==
+             [1, 2]
+             |> ConcurrencyLimiter.wrap_stream(completed_lease)
+             |> Enum.to_list()
+
+    assert %{active: 0} = ConcurrencyLimiter.status(key)
+
+    assert {:ok, halted_lease} = ConcurrencyLimiter.acquire(key)
+
+    assert [1] ==
+             Stream.cycle([1, 2])
+             |> ConcurrencyLimiter.wrap_stream(halted_lease)
+             |> Enum.take(1)
+
+    assert %{active: 0} = ConcurrencyLimiter.status(key)
+
+    assert {:ok, raised_lease} = ConcurrencyLimiter.acquire(key)
+
+    stream =
+      Stream.map([:event], fn _event -> raise "stream failed" end)
+      |> ConcurrencyLimiter.wrap_stream(raised_lease)
+
+    assert_raise RuntimeError, "stream failed", fn -> Enum.to_list(stream) end
+    assert %{active: 0} = ConcurrencyLimiter.status(key)
+  end
+
+  test "repeated stream cancellation returns the active count to zero" do
+    key = limited_key(1)
+
+    for iteration <- 1..25 do
+      parent = self()
+      assert {:ok, lease} = ConcurrencyLimiter.acquire(key)
+
+      {pid, monitor} =
+        spawn_monitor(fn ->
+          stream =
+            Stream.repeatedly(fn ->
+              send(parent, {:stream_waiting, iteration, self()})
+
+              receive do
+                :continue -> :event
+              end
+            end)
+            |> ConcurrencyLimiter.wrap_stream(lease)
+
+          Enum.to_list(stream)
+        end)
+
+      assert_receive {:stream_waiting, ^iteration, ^pid}, 1_000
+      assert %{active: 1} = ConcurrencyLimiter.status(key)
+
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^pid, :killed}, 1_000
+      assert_eventually(fn -> ConcurrencyLimiter.status(key).active == 0 end)
+    end
+  end
+
+  defp limited_key(limit) do
+    %{
+      id: "concurrency-test-#{System.unique_integer([:positive])}",
+      budget_limits: [Limit.concurrent_requests(limit)]
+    }
+  end
+
+  defp assert_eventually(fun, attempts \\ 50) do
+    cond do
+      fun.() ->
+        :ok
+
+      attempts > 0 ->
+        Process.sleep(10)
+        assert_eventually(fun, attempts - 1)
+
+      true ->
+        flunk("condition did not become true")
+    end
+  end
+end

--- a/test/llm_proxy/provider/safe_rpc_test.exs
+++ b/test/llm_proxy/provider/safe_rpc_test.exs
@@ -2,6 +2,7 @@ defmodule LLMProxy.Provider.SafeRPCTest do
   use ExUnit.Case
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias LLMProxy.{ConcurrencyLimiter, Limit}
   alias LLMProxy.Providers.{Registry, Result}
   alias LLMProxy.Storage
   alias LLMProxy.TestSupport
@@ -63,6 +64,29 @@ defmodule LLMProxy.Provider.SafeRPCTest do
 
     assert ReqLLM.Response.text(response) == "hello over SafeRPC"
     assert response.usage.input_tokens == 5
+
+    GenServer.stop(server)
+  end
+
+  test "SafeRPC calls share the concurrent-request limit" do
+    {:ok, key, raw_key} =
+      Storage.create_key("safe-rpc-concurrent-user", %{
+        budget_limits: [Limit.concurrent_requests(1)]
+      })
+
+    socket = socket_path("concurrency")
+    {:ok, server} = Server.start_link(socket: socket)
+    Sandbox.allow(LLMProxy.Storage.Repo.SQLite, self(), server)
+
+    assert {:ok, lease} = ConcurrencyLimiter.acquire(key)
+
+    on_exit(fn -> ConcurrencyLimiter.release(lease) end)
+
+    assert {:ok, request} =
+             LLMProxy.Provider.chat_request("hello", model: "req-llm-safe-rpc-model")
+
+    assert {:error, {:concurrency_limit, 1}} =
+             SafeRPC.call(socket, {LLMProxy, :chat}, request, meta: %{api_key: raw_key})
 
     GenServer.stop(server)
   end

--- a/test/llm_proxy/provider_test.exs
+++ b/test/llm_proxy/provider_test.exs
@@ -1,6 +1,7 @@
 defmodule LLMProxy.ProviderTest do
   use ExUnit.Case
 
+  alias LLMProxy.{ConcurrencyLimiter, Limit}
   alias LLMProxy.Protocol.Request
   alias LLMProxy.Providers.{Registry, Result}
   alias LLMProxy.Storage
@@ -111,5 +112,37 @@ defmodule LLMProxy.ProviderTest do
     [updated_key] = Storage.list_keys()
     assert updated_key.input_tokens == 4
     assert updated_key.output_tokens == 3
+  end
+
+  test "local and ReqLLM calls share the concurrent-request limit" do
+    {:ok, key, raw_key} =
+      Storage.create_key("concurrent-provider-user", %{
+        budget_limits: [Limit.concurrent_requests(1)]
+      })
+
+    assert {:ok, lease} = ConcurrencyLimiter.acquire(key)
+    on_exit(fn -> ConcurrencyLimiter.release(lease) end)
+
+    assert {:error, {:concurrency_limit, 1}} =
+             LLMProxy.chat("hello", model: "req-llm-provider-model", api_key: key)
+
+    model = %{
+      id: "req-llm-provider-model",
+      provider: :llm_proxy,
+      model: "req-llm-provider-model"
+    }
+
+    assert {:error,
+            %ReqLLM.Error.API.Request{
+              status: 429,
+              response_body: %{
+                "error" => %{
+                  "code" => "rate_limit_error",
+                  "message" => message
+                }
+              }
+            }} = ReqLLM.Generation.generate_text(model, "hello", api_key: raw_key)
+
+    assert message == ConcurrencyLimiter.error_message()
   end
 end

--- a/test/llm_proxy/router_test.exs
+++ b/test/llm_proxy/router_test.exs
@@ -38,6 +38,15 @@ defmodule LLMProxy.RouterDynamicTest do
     assert body["ready"] == true
     assert body["draining"] == false
     assert body["active"] == %{"agents" => 0, "requests" => 0, "streams" => 0, "total" => 0}
+
+    assert %{
+             "active" => active,
+             "admitted" => admitted,
+             "rejected" => rejected,
+             "released" => released
+           } = body["concurrency"]
+
+    assert Enum.all?([active, admitted, rejected, released], &is_integer/1)
   end
 
   test "health remains available while user routes reject during drain" do

--- a/test/llm_proxy/routes/chat_test.exs
+++ b/test/llm_proxy/routes/chat_test.exs
@@ -2,6 +2,7 @@ defmodule LLMProxy.HTTP.Routes.ChatTest do
   use ExUnit.Case
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias LLMProxy.{ConcurrencyLimiter, Limit}
   alias LLMProxy.HTTP.Routes.Chat
   alias LLMProxy.Providers.{Registry, Result}
   alias LLMProxy.Storage
@@ -289,7 +290,11 @@ defmodule LLMProxy.HTTP.Routes.ChatTest do
 
   test "stream remains active until the response stream finishes" do
     Application.put_env(:llm_proxy, :blocking_stream_parent, self())
-    {:ok, _key, raw_key} = Storage.create_key("blocking-stream-user")
+
+    {:ok, key, raw_key} =
+      Storage.create_key("blocking-stream-user", %{
+        budget_limits: [Limit.concurrent_requests(1)]
+      })
 
     task =
       Task.async(fn ->
@@ -311,7 +316,21 @@ defmodule LLMProxy.HTTP.Routes.ChatTest do
     send(task_pid, :start_blocking_stream)
 
     assert_receive {:blocking_stream_waiting, stream_pid}
+    assert %{active: 1, limit: 1} = ConcurrencyLimiter.status(key)
     assert %{active: %{streams: 1, total: 1}, serving: true} = LLMProxy.Drain.status()
+
+    rejected_conn =
+      TestSupport.json_conn(:post, "/completions", %{
+        "model" => "fake-chat-model",
+        "messages" => [%{"role" => "user", "content" => "second"}]
+      })
+      |> TestSupport.put_bearer(raw_key)
+      |> Chat.call(Chat.init([]))
+
+    assert rejected_conn.status == 429
+    assert Plug.Conn.get_resp_header(rejected_conn, "retry-after") == ["1"]
+    assert get_in(Jason.decode!(rejected_conn.resp_body), ["error", "code"]) == "rate_limit_error"
+
     assert %{draining: true, ready: false} = LLMProxy.Drain.start()
     assert {:error, :timeout} = LLMProxy.Drain.await_empty(10)
 
@@ -321,6 +340,7 @@ defmodule LLMProxy.HTTP.Routes.ChatTest do
     assert conn.status == 200
     assert conn.state == :chunked
     assert :ok = LLMProxy.Drain.await_empty(100)
+    assert %{active: 0, limit: 1} = ConcurrencyLimiter.status(key)
     assert %{active: %{streams: 0, total: 0}, serving: false} = LLMProxy.Drain.status()
   end
 

--- a/test/llm_proxy/routes/message_endpoint_test.exs
+++ b/test/llm_proxy/routes/message_endpoint_test.exs
@@ -1,6 +1,7 @@
 defmodule LLMProxy.HTTP.Routes.MessageEndpointTest do
   use ExUnit.Case
 
+  alias LLMProxy.{ConcurrencyLimiter, Limit}
   alias LLMProxy.HTTP.Routes.MessageEndpoint
   alias LLMProxy.Providers.{Registry, Result}
   alias LLMProxy.Storage
@@ -248,6 +249,35 @@ defmodule LLMProxy.HTTP.Routes.MessageEndpointTest do
 
     assert conn.status == 429
     assert get_in(Jason.decode!(conn.resp_body), ["error", "message"]) == "provider failed"
+  end
+
+  test "returns an Anthropic rate-limit error when concurrent capacity is full" do
+    {:ok, key, raw_key} =
+      Storage.create_key("messages-concurrent-user", %{
+        budget_limits: [Limit.concurrent_requests(1)]
+      })
+
+    assert {:ok, lease} = ConcurrencyLimiter.acquire(key)
+    on_exit(fn -> ConcurrencyLimiter.release(lease) end)
+
+    conn =
+      TestSupport.json_conn(:post, "/", %{
+        "model" => "fake-messages-model",
+        "messages" => [%{"role" => "user", "content" => "hello"}]
+      })
+      |> TestSupport.put_bearer(raw_key)
+      |> MessageEndpoint.call(MessageEndpoint.init([]))
+
+    assert conn.status == 429
+    assert Plug.Conn.get_resp_header(conn, "retry-after") == ["1"]
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "type" => "error",
+             "error" => %{
+               "type" => "rate_limit_error",
+               "message" => ConcurrencyLimiter.error_message()
+             }
+           }
   end
 
   test "returns 404 for unknown routes" do

--- a/test/llm_proxy/routes/moderation_endpoint_test.exs
+++ b/test/llm_proxy/routes/moderation_endpoint_test.exs
@@ -1,6 +1,7 @@
 defmodule LLMProxy.HTTP.Routes.ModerationEndpointTest do
   use ExUnit.Case
 
+  alias LLMProxy.{ConcurrencyLimiter, Limit}
   alias LLMProxy.HTTP.Routes.ModerationEndpoint
   alias LLMProxy.Storage
   alias LLMProxy.TestSupport
@@ -43,6 +44,28 @@ defmodule LLMProxy.HTTP.Routes.ModerationEndpointTest do
 
     assert get_in(Jason.decode!(conn.resp_body), ["error", "message"]) ==
              "No OpenAI token available"
+  end
+
+  test "returns a rate-limit error when concurrent capacity is full" do
+    {:ok, key, raw_key} =
+      Storage.create_key("moderation-concurrent-user", %{
+        budget_limits: [Limit.concurrent_requests(1)]
+      })
+
+    assert {:ok, lease} = ConcurrencyLimiter.acquire(key)
+    on_exit(fn -> ConcurrencyLimiter.release(lease) end)
+
+    conn =
+      TestSupport.json_conn(:post, "/", %{"input" => "hello"})
+      |> TestSupport.put_bearer(raw_key)
+      |> ModerationEndpoint.call(ModerationEndpoint.init([]))
+
+    assert conn.status == 429
+    assert Plug.Conn.get_resp_header(conn, "retry-after") == ["1"]
+    assert get_in(Jason.decode!(conn.resp_body), ["error", "code"]) == "rate_limit_error"
+
+    assert get_in(Jason.decode!(conn.resp_body), ["error", "message"]) ==
+             ConcurrencyLimiter.error_message()
   end
 
   test "normalizes upstream moderation errors" do


### PR DESCRIPTION
## Summary

- add per-key concurrent-request limits at the common provider boundary
- keep stream leases until completion, halt, exception, or owner exit
- return protocol-correct HTTP 429 responses and expose content-free counters
- document per-runtime-instance semantics and add repeated cleanup coverage

Closes #2.

## Verification

- Running ExUnit with seed: 910521, max_cases: 20
Excluding tags: [:integration]

................................................................................................................................................
15:55:21.507 [warning] limited/m rate-limited, trying fallback
....
15:55:21.507 [warning] fail/m returned 500 (server error), trying fallback
.
15:55:21.507 [warning] auth_fail/m failed (401): unauthorized
..
15:55:21.507 [warning] raising/m returned 500 (Internal provider execution failed), trying fallback
..
15:55:21.508 [warning] retry-after/m rate-limited, trying fallback
.
15:55:21.508 [warning] fail/m returned 500 (server error), trying fallback
.
15:55:21.508 [warning] auth_fail/m failed (401) (stream): unauthorized
.
15:55:21.508 [warning] fail/m returned 500 (server error), trying fallback (stream)
.............................
15:55:21.634 [warning] Token 1 marked as rate-limited
.............LLMProxy drain started: %{active: %{total: 0, streams: 0, requests: 0, agents: 0}, draining: true, ready: false, serving: false}
LLMProxy drain canceled: %{active: %{total: 0, streams: 0, requests: 0, agents: 0}, draining: false, ready: true, serving: false}
..%{
  active: %{total: 0, streams: 0, requests: 0, agents: 0},
  draining: false,
  ready: true,
  serving: false
}
.LLMProxy drain started: %{active: %{total: 0, streams: 0, requests: 0, agents: 0}, draining: true, ready: false, serving: false}
LLMProxy drain canceled: %{active: %{total: 0, streams: 0, requests: 0, agents: 0}, draining: false, ready: true, serving: false}
.LLMProxy drain started: %{active: %{total: 1, streams: 1, requests: 0, agents: 0}, draining: true, ready: false, serving: true}
LLMProxy drain canceled: %{active: %{total: 1, streams: 1, requests: 0, agents: 0}, draining: false, ready: true, serving: true}
......
15:55:21.803 [warning] provider-routing-test/primary-routing-model returned 500 (primary failed), trying fallback
...................................................................
15:55:21.900 [error] Moderation provider error (400): Invalid moderation input
.......
15:55:21.906 [warning] Token 1 marked as rate-limited
..
15:55:21.908 [warning] Token 1 marked as rate-limited
.
15:55:21.911 [warning] timeout-routing-test/slow-model returned 504 (Provider timed out after 1ms), trying fallback
.
15:55:21.915 [warning] circuit-routing-test/broken-model returned 500 (broken), trying fallback
..
15:55:21.921 [warning] recovery-routing-test/recovery-model returned 500 (temporary), trying fallback
...............
15:55:21.947 [warning] fake-chat/fake-chat-error returned 502 (upstream failed), trying fallback
..
15:55:21.952 [warning] fake-chat/fake-chat-detailed-error failed (400): Provider returned error

15:55:21.952 [error] Provider error (400): Provider returned error
.
15:55:21.953 [error] Stream pipeline failed provider=fake-chat model=fake-chat-midstream-failure trace_id=GM6KoAJzbzDH3R8AAAZj status=502 code=upstream_error exception=RuntimeError reason="upstream disconnected"
.
15:55:21.954 [warning] fake-chat/fake-chat-error returned 502 (upstream failed), trying fallback

15:55:21.955 [error] Provider error (502): upstream failed
.
15:55:21.955 [error] Stream pipeline failed provider=fake-chat model=fake-chat-preflight-failure trace_id=GM6KoAKXVm7HdAUAABhB status=502 code=upstream_error exception=RuntimeError reason="model is not available"

15:55:21.956 [error] fake-chat error (400): model is not available
..........................
15:55:24.986 [warning] Token 1 marked as rate-limited
.
15:55:24.990 [warning] fake-responses/fake-responses-error returned 500 (response failed), trying fallback (native)

15:55:24.991 [error] fake-responses error (500): response failed
..
15:55:24.994 [warning] fake-responses/fake-responses-rate-limited returned 429 (slow down), trying fallback (native)

15:55:24.994 [warning] Token 1 marked as rate-limited

15:55:24.994 [error] fake-responses error (429): slow down
...
15:55:24.996 [error] Stream pipeline failed provider=fake-responses model=fake-responses-midstream-failure trace_id=GM6KoLfX26Kli7IAABlB status=502 code=upstream_error exception=RuntimeError reason="responses upstream disconnected"
..
15:55:24.998 [error] Stream pipeline failed provider=fake-responses model=fake-responses-preflight-failure trace_id=GM6KoLf5Yao-BjQAAAwm status=502 code=upstream_error exception=RuntimeError reason="responses model unavailable"

15:55:24.999 [error] fake-responses error (400): responses model unavailable
.......................
15:55:25.055 [error] fake-messages error (401): auth failed
.....
15:55:25.062 [warning] fake-messages/fake-messages-error returned 429 (provider failed), trying fallback (native)
.
15:55:25.062 [error] fake-messages error (429): provider failed

15:55:25.063 [error] Stream pipeline failed provider=fake-messages model=fake-messages-preflight-failure trace_id=GM6KoLvWNvEkDuoAAAVq status=502 code=upstream_error exception=RuntimeError reason="messages model unavailable"

15:55:25.064 [error] fake-messages error (400): messages model unavailable
.
15:55:25.065 [error] fake-messages error (400): bad request
..
15:55:25.067 [error] Stream pipeline failed provider=fake-messages model=fake-messages-midstream-failure trace_id=GM6KoLwHGcCxwjkAABFF status=502 code=upstream_error exception=RuntimeError reason="messages upstream disconnected"
...
Finished in 4.1 seconds (0.7s async, 3.3s sync)

Result: 377 passed, 8 excluded
Checking 185 source files (this might take a while) ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.5 seconds (0.03s to load, 0.5s running 69 checks on 185 files)
2110 mods/funs, found no issues.

Use `mix credo explain` to explain issues, `mix credo --help` for options.
Finding suitable PLTs
Checking PLT...
[:abnf_parsec, :acceptor_pool, :asn1, :castore, :chatterbox, :compiler, :cowboy, :cowboy_telemetry, :cowlib, :crypto, :ctx, :db_connection, :decimal, :dotenvy, :dsl, :ecto, :ecto_sql, :ecto_sqlite3, :eex, :elixir, :ex_ast, :exqlite, :file_system, :finch, :floki, :glob_ex, :gproc, :grpcbox, :hex_solver, :hpack, :hpax, :idna, :igniter, :incant, :inets, :jason, :json_codec, :jsv, :kernel, :lazy_html, :llm_proxy, :logger, :mime, :mint, :mint_web_socket, :mix, :mox, :muontrap, :nimble_options, :nimble_ownership, :nimble_parsec, :nimble_pool, :npm, :npm_semver, :opentelemetry, :opentelemetry_api, :opentelemetry_cowboy, :opentelemetry_ecto, :opentelemetry_exporter, :opentelemetry_process_propagator, :opentelemetry_req, :opentelemetry_semantic_conventions, :opentelemetry_telemetry, :otel_http, :owl, :oxc, :oxide_ex, :phoenix, :phoenix_html, :phoenix_live_view, :phoenix_pubsub, :phoenix_template, :plug, :plug_cowboy, :plug_crypto, :public_key, :quackdb, :quickbeam, :ranch, :req, :req_llm, :rewrite, :rustler_precompiled, :safe_rpc, :server_sent_events, :sourceror, :spitfire, :splode, :ssl, :ssl_verify_fun, :stdlib, :telemetry, :text_diff, :texture, :tls_certificate_check, :toml, :varint, :vibe_kit, :vize, :volt, :websock, :websock_adapter, :websockex, :xmerl, :zigler_precompiled, :zoi]
PLT is up to date!
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: ~c"/Users/mhostetler/Source/ReqLLM/proj_llmux/llm_proxy/_build/test/dialyxir_erlang-29.0.5_elixir-1.20.3_deps-test.plt",
  files: [~c"/Users/mhostetler/Source/ReqLLM/proj_llmux/llm_proxy/_build/test/lib/llm_proxy/ebin/Elixir.LLMProxy.Config.TOML.beam",
   ~c"/Users/mhostetler/Source/ReqLLM/proj_llmux/llm_proxy/_build/test/lib/llm_proxy/ebin/Elixir.LLMProxy.Schemas.ServiceUsage.beam",
   ~c"/Users/mhostetler/Source/ReqLLM/proj_llmux/llm_proxy/_build/test/lib/llm_proxy/ebin/Elixir.LLMProxy.Pricing.Rates.beam",
   ~c"/Users/mhostetler/Source/ReqLLM/proj_llmux/llm_proxy/_build/test/lib/llm_proxy/ebin/Elixir.LLMProxy.Providers.OpenAICodex.OAuth.Login.AccessTokenClaims.beam",
   ~c"/Users/mhostetler/Source/ReqLLM/proj_llmux/llm_proxy/_build/test/lib/llm_proxy/ebin/Elixir.LLMProxy.HTTP.Routes.Feedback.beam",
   ...],
  ...
]
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m4.17s
done (passed successfully)

[32m  ✓ No code duplication detected[0m[2m (107 files)
[0m
  Detection time:     418ms

  Clone budget:       0/0

Analyzing project...

────────────────────────────────────────
  Architecture Policy
────────────────────────────────────────
  OK

────────────────────────────────────────
  Cross-Function Smell Detection
────────────────────────────────────────
  (no issues): 377 passed, 8 configured external integration tests excluded
- Credo, Dialyzer, ExDNA, and Reach passed
- limiter stress test repeated 50 times, with 1,250 forced stream-consumer cancellation cycles and no retained leases