### PR TITLE
feat: track live provider usage windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@
 - A supervised provider-usage tracker now reports each configured OpenAI Codex
   or GLM Coding Plan account separately. The optional Incant admin surface shows
   live upstream windows, availability, reset times, freshness, and safe errors,
-  with bounded automatic refresh and manual refresh actions.
+  with bounded automatic refresh and manual refresh actions. Provider payloads
+  use strict JSONCodec boundaries, response sizes are capped, and malformed or
+  out-of-scope refresh results fail atomically.
 - Provider-token pools support affinity or fill-first selection. Fill-first
   orders healthy tokens within the existing OAuth-first/API-key-fallback
   boundary by persisted non-negative priority and stable token ID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ### Added
 
+- A supervised provider-usage tracker now reports each configured OpenAI Codex
+  or GLM Coding Plan account separately. The optional Incant admin surface shows
+  live upstream windows, availability, reset times, freshness, and safe errors,
+  with bounded automatic refresh and manual refresh actions.
 - An optional public-model allowlist keeps HTTP discovery, setup helpers,
   SafeRPC status, and request admission aligned. Standalone deployments
   configure visible aliases through `catalog.public_models` in strict TOML;

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Every authenticated request runs through the same controls:
 6. Record usage, estimated cost, latency, and trace IDs without retaining prompts or model output unless content capture is explicitly enabled.
 7. Emit OpenTelemetry spans and return the trace ID to the caller.
 
-Incant support is optional. When installed, `LLMProxy.Admin` describes resources for API keys, provider tokens, traces, and messages plus an operations dashboard. A separate Incant host can consume those surfaces over SafeRPC; the public gateway does not expose an admin UI.
+Incant support is optional. When installed, `LLMProxy.Admin` describes resources for API keys, provider tokens, traces, and messages plus operations and live provider-usage dashboards. The usage dashboard reads authoritative upstream windows for configured OpenAI Codex and GLM Coding Plan accounts. A separate Incant host can consume those surfaces over SafeRPC; the public gateway does not expose an admin UI.
 
 See [Governance and Observability](https://hexdocs.pm/llm_proxy/governance-and-observability.html), [Cache and Guardrails](https://hexdocs.pm/llm_proxy/cache-and-guardrails.html), and [Admin Integration](https://hexdocs.pm/llm_proxy/admin-integration.html).
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,6 +15,7 @@ config :llm_proxy, LLMProxy.Storage.Repo.SQLite,
 
 config :llm_proxy,
   master_key: System.get_env("MASTER_KEY", "test-master-key"),
+  provider_usage_auto_refresh: false,
   providers: %{
     "anthropic" => %{api_keys: System.get_env("ANTHROPIC_API_KEYS", "")},
     "openai" => %{api_keys: System.get_env("OPENAI_API_KEYS", "")},

--- a/guides/features/admin-integration.md
+++ b/guides/features/admin-integration.md
@@ -35,6 +35,7 @@ LLMProxy compiles its admin modules only when Incant is available. Without Incan
 - **Traces** — inspect recorded request/response traces and feedback.
 - **Messages** — inspect redacted message records and linked usage. Raw captured text stays on an authorized storage path.
 - **Operations dashboard** — review request volume, token usage, spend, latency, and recent failures.
+- **Provider Usage dashboard** — review each configured Codex or GLM Coding Plan account, its live upstream windows, remaining capacity, reset time, availability, and refresh state.
 
 Policies remain inside the LLMProxy service VM. A remote Incant host receives data and dispatches actions; it does not receive repos, schemas, callback functions, or provider secrets as executable terms.
 
@@ -116,6 +117,56 @@ On completion, LLMProxy stores refreshable credentials in `provider_tokens`. Lat
 Prefer this live admin flow for standalone services because it uses the running storage owner. `bin/codex_login` remains available for local recovery, but starts a separate VM and may require the service to be stopped when storage ownership is exclusive.
 
 Before any Codex token exists, Codex requests fail with `No available OpenAI Codex OAuth tokens: no_tokens` rather than falling through to an unrelated credential pool.
+
+## Live provider usage
+
+The provider-usage tracker starts with LLMProxy and keeps one in-memory snapshot per supported provider-token record. It runs one sequential refresh task. A second automatic or manual refresh cannot overlap it. Snapshots do not contain access tokens, refresh tokens, cookies, or provider account IDs. SafeRPC receives only the redacted account label, percentages, timestamps, availability, freshness, and safe error text.
+
+OpenAI Codex usage comes from the same account-rate-limit source used by the [first-party Codex backend client](https://github.com/openai/codex/blob/main/codex-rs/backend-client/src/client/rate_limit_resets.rs). With the default `https://chatgpt.com/backend-api` base, LLMProxy uses `GET /backend-api/wham/usage`. A custom base without `/backend-api` uses its `/api/codex/usage` path. The request requires a valid Codex OAuth access token. `ChatGPT-Account-Id` is sent when the stored token or access-token claim provides it, but the ID is never returned to Incant.
+
+GLM Coding Plan usage comes from the Z.AI monitor API on the configured provider origin. Providers using the `zai`, `zai_coder`, or `zai_coding_plan` ReqLLM adapter qualify automatically. A custom provider can set `usage_adapter: "glm"`. The default source order is:
+
+1. `/api/monitor/usage/quota/limit`, used by [Z.AI's first-party GLM usage plugin](https://github.com/zai-org/zai-coding-plugins/blob/main/plugins/glm-plan-usage/skills/usage-query-skill/scripts/query-usage.mjs).
+2. `/api/monitor/usage`, used only as a bounded fallback after an authentication or not-found reply because current Coding Plan responses have also been observed there.
+
+The GLM monitor surface is not in the general public Z.AI API reference. Response forms differ by plan and rollout. LLMProxy accepts `TOKENS_LIMIT` and current `CREDIT_LIMIT` windows. It also accepts the monthly `TIME_LIMIT` tool window. If a reply does not contain `nextResetTime`, the dashboard shows no reset value. It does not calculate one.
+
+Configure a GLM Coding Plan provider and an isolated token pool:
+
+```toml
+[providers.glm-coding]
+adapter = "zai_coding_plan"
+base_url = "https://api.z.ai/api/coding/paas/v4"
+token_pool = "glm-production"
+```
+
+Add each account API key as a separate `provider_tokens` row in `glm-production`, or seed the pool through `LLM_PROXY_PROVIDER_KEYS`. Use a short operational label such as `prod-east`. Usage output always masks a valid label, for example `p***t`, and adds the local token ID. Labels with unsafe characters, including email addresses, become `Account #<local token id>`.
+
+The first-party GLM usage plugin sends the API key as the raw `Authorization` value, which is the default. If the account endpoint requires a bearer scheme, set `usage_auth_scheme = "bearer"`. To select one qualified endpoint explicitly, set `usage_paths = ["/api/monitor/usage"]`. Usage URLs must use HTTPS, endpoint lists are limited to three paths, redirects are disabled, and per-token proxy overrides are not used for usage requests.
+
+Automatic refresh defaults to five minutes. The supported interval is one minute through one hour. The request deadline is one through 30 seconds. Standalone settings belong in TOML:
+
+```toml
+[provider_usage]
+auto_refresh = true
+refresh_interval_ms = 300000
+request_timeout_ms = 10000
+stale_after_ms = 600000
+```
+
+Library applications can set the same values in application configuration:
+
+```elixir
+config :llm_proxy,
+  provider_usage_auto_refresh: true,
+  provider_usage_refresh_interval_ms: 300_000,
+  provider_usage_request_timeout_ms: 10_000,
+  provider_usage_stale_after_ms: 600_000
+```
+
+Set `provider_usage.auto_refresh = false` in standalone TOML to use only the Provider Tokens resource actions. Library applications set `provider_usage_auto_refresh: false` in Elixir configuration. `Refresh provider usage` starts a bounded refresh of all supported accounts. The row action refreshes one supported account. Both actions return before upstream I/O completes, so they stay inside the SafeRPC request deadline.
+
+Disabled tokens appear as unavailable and are not decoded or sent. Authentication failures, unsupported or absent quota APIs, timeouts, rate limits, malformed responses, and stale retained data have separate states. A failed refresh keeps the last successful windows and marks them stale.
 
 ## Backups
 

--- a/guides/features/admin-integration.md
+++ b/guides/features/admin-integration.md
@@ -142,7 +142,7 @@ token_pool = "glm-production"
 
 Add each account API key as a separate `provider_tokens` row in `glm-production`, or seed the pool through `LLM_PROXY_PROVIDER_KEYS`. Use a short operational label such as `prod-east`. Usage output always masks a valid label, for example `p***t`, and adds the local token ID. Labels with unsafe characters, including email addresses, become `Account #<local token id>`.
 
-The first-party GLM usage plugin sends the API key as the raw `Authorization` value, which is the default. If the account endpoint requires a bearer scheme, set `usage_auth_scheme = "bearer"`. To select one qualified endpoint explicitly, set `usage_paths = ["/api/monitor/usage"]`. Usage URLs must use HTTPS, endpoint lists are limited to three paths, redirects are disabled, and per-token proxy overrides are not used for usage requests.
+The first-party GLM usage plugin sends the API key as the raw `Authorization` value, which is the default. If the account endpoint requires a bearer scheme, set `usage_auth_scheme = "bearer"`. To select one qualified endpoint explicitly, set `usage_paths = ["/api/monitor/usage"]`. Usage URLs must use HTTPS, endpoint lists are limited to three paths, redirects are disabled, and responses are capped at 256,000 bytes before JSON decoding. Tokens with per-token endpoint overrides are reported as unsupported without sending their credentials; configure a provider-level usage origin instead.
 
 Automatic refresh defaults to five minutes. The supported interval is one minute through one hour. The request deadline is one through 30 seconds. Standalone settings belong in TOML:
 

--- a/guides/features/providers-and-routing.md
+++ b/guides/features/providers-and-routing.md
@@ -76,6 +76,17 @@ LLM_PROXY_PROVIDER_KEYS='{"example-production":["secret-a","secret-b"]}'
 
 Persisted provider tokens remain the runtime source after seeding. A token record can override the provider base URL through its `proxy` field, but that should be reserved for intentional per-token gateways; normal endpoints belong in provider configuration.
 
+GLM Coding Plan providers can use ReqLLM's native Z.AI adapter and the same isolated pool for live account-window tracking:
+
+```toml
+[providers.glm-coding]
+adapter = "zai_coding_plan"
+base_url = "https://api.z.ai/api/coding/paas/v4"
+token_pool = "glm-production"
+```
+
+Each API key in `glm-production` is one account in the Provider Usage dashboard. Custom compatible configurations can opt in with `usage_adapter = "glm"`. See [Admin Integration](admin-integration.md#live-provider-usage) for qualified endpoints, authentication, refresh bounds, and unsupported states.
+
 ## Public model aliases
 
 A readable library configuration uses model aliases and routes:

--- a/guides/reference/configuration.cheatmd
+++ b/guides/reference/configuration.cheatmd
@@ -262,6 +262,21 @@ Default endpoint for a named or built-in provider.
 
 Default credential pool for provider routes.
 
+### GLM Usage Source
+
+```elixir
+%{
+  adapter: "zai_coding_plan",
+  base_url: "https://api.z.ai/api/coding/paas/v4",
+  token_pool: "glm-production",
+  usage_adapter: "glm",
+  usage_auth_scheme: "raw",
+  usage_paths: ["/api/monitor/usage/quota/limit", "/api/monitor/usage"]
+}
+```
+
+`usage_adapter` is optional for `zai`, `zai_coder`, and `zai_coding_plan`. Usage paths must be HTTPS-origin paths. At most three paths are accepted.
+
 ### Anthropic Defaults
 
 ```elixir
@@ -427,6 +442,20 @@ provider_connect_timeout_ms = 10000
 
 Fallback deployments belong in model routes, not a separate fallback map.
 
+### Provider Usage
+
+```toml
+[provider_usage]
+auto_refresh = true
+refresh_interval_ms = 300000
+request_timeout_ms = 10000
+stale_after_ms = 600000
+```
+
+The refresh interval must be from `60000` through `3600000`. The request timeout
+must be from `1000` through `30000`. The stale time must be at least the refresh
+interval and no more than `86400000`. Omitted values use the built-in defaults.
+
 ### Telemetry
 
 ```toml
@@ -455,6 +484,8 @@ adapter = "openai"
 base_url = "https://api.example.com/v1"
 token_pool = "example-production"
 ```
+
+Optional provider usage keys are `usage_adapter`, `usage_auth_scheme`, and `usage_paths`.
 
 ### Model
 

--- a/guides/reference/configuration.cheatmd
+++ b/guides/reference/configuration.cheatmd
@@ -299,7 +299,7 @@ Default credential pool for provider routes.
 }
 ```
 
-`usage_adapter` is optional for `zai`, `zai_coder`, and `zai_coding_plan`. Usage paths must be HTTPS-origin paths. At most three paths are accepted.
+`usage_adapter` is optional for `zai`, `zai_coder`, and `zai_coding_plan`; when present it must be the string `"glm"`. `usage_auth_scheme` must be `"raw"` or `"bearer"`. `usage_paths` must be a non-empty list of at most three distinct absolute origin paths. Invalid values fail configuration loading rather than being coerced or ignored.
 
 ### Anthropic Defaults
 

--- a/guides/reference/configuration.cheatmd
+++ b/guides/reference/configuration.cheatmd
@@ -299,7 +299,7 @@ Default credential pool for provider routes.
 }
 ```
 
-`usage_adapter` is optional for `zai`, `zai_coder`, and `zai_coding_plan`; when present it must be the string `"glm"`. `usage_auth_scheme` must be `"raw"` or `"bearer"`. `usage_paths` must be a non-empty list of at most three distinct absolute origin paths. Invalid values fail configuration loading rather than being coerced or ignored.
+`usage_adapter` is optional for `zai`, `zai_coder`, and `zai_coding_plan`; when present it must be the string `"glm"`. `usage_auth_scheme` must be `"raw"` or `"bearer"`. `usage_paths` must be a non-empty list of at most three distinct absolute origin paths. Raw whitespace and control bytes are rejected; encode valid path characters when needed. Invalid values fail configuration loading rather than being coerced or ignored.
 
 ### Anthropic Defaults
 

--- a/lib/llm_proxy/admin.ex
+++ b/lib/llm_proxy/admin.ex
@@ -31,6 +31,7 @@ if Code.ensure_loaded?(Incant) do
     expose(LLMProxy.Schemas.MessageLog, as: :message, readonly: true)
 
     dashboard(LLMProxy.Admin.Dashboards.Operations)
+    dashboard(LLMProxy.Admin.Dashboards.ProviderUsage)
 
     @impl Incant.Service
     def index(surface_id, params, context) when is_binary(surface_id) do

--- a/lib/llm_proxy/admin/dashboards/provider_usage.ex
+++ b/lib/llm_proxy/admin/dashboards/provider_usage.ex
@@ -1,0 +1,54 @@
+if Code.ensure_loaded?(Incant) do
+  defmodule LLMProxy.Admin.Dashboards.ProviderUsage do
+    @moduledoc "Live, redacted provider usage-window dashboard."
+
+    use Incant.Dashboard
+
+    title("Provider Usage")
+
+    grid columns: 12 do
+      stat(:accounts, span: 4, label: "Tracked accounts", query: &__MODULE__.accounts/2)
+
+      stat(:available,
+        span: 4,
+        label: "Available accounts",
+        query: &__MODULE__.available/2
+      )
+
+      stat(:attention,
+        span: 4,
+        label: "Need attention",
+        query: &__MODULE__.attention/2
+      )
+
+      table :usage_windows,
+        span: 12,
+        label: "Live usage windows",
+        preview_rows: 50,
+        query: &__MODULE__.usage_windows/2 do
+        column(:provider, label: "Provider", priority: :primary)
+        column(:account, label: "Account", priority: :primary)
+        column(:window, label: "Window", priority: :primary)
+        column(:used_percent, label: "Used %", format: :number, priority: :primary)
+
+        column(:remaining_percent,
+          label: "Remaining %",
+          format: :number,
+          priority: :secondary
+        )
+
+        column(:resets_at, label: "Resets or expires", format: :datetime, priority: :secondary)
+        column(:availability, label: "Availability", priority: :primary)
+        column(:state, label: "Refresh state", priority: :secondary)
+        column(:last_refresh, label: "Last refresh", format: :relative, priority: :secondary)
+        column(:last_attempt, label: "Last attempt", format: :relative, priority: :tertiary)
+        column(:error, label: "Error", priority: :secondary)
+      end
+    end
+
+    def accounts(_variables, _context), do: LLMProxy.ProviderUsage.account_count()
+    def available(_variables, _context), do: LLMProxy.ProviderUsage.available_count()
+    def attention(_variables, _context), do: LLMProxy.ProviderUsage.attention_count()
+    def usage_windows(_variables, _context), do: LLMProxy.ProviderUsage.rows()
+  end
+end

--- a/lib/llm_proxy/admin/resources/provider_token.ex
+++ b/lib/llm_proxy/admin/resources/provider_token.ex
@@ -38,6 +38,11 @@ if Code.ensure_loaded?(Incant) do
         callback: :enable
       )
 
+      action(:refresh_usage,
+        available_if: [enabled: true],
+        callback: :refresh_usage
+      )
+
       action(:remove, confirm: true, destructive: true, callback: :remove)
 
       actions do
@@ -50,6 +55,11 @@ if Code.ensure_loaded?(Incant) do
           label: "Complete Codex OAuth",
           callback: {LLMProxy.Admin.CodexOAuth, :complete}
         )
+
+        page(:refresh_all_usage,
+          label: "Refresh provider usage",
+          callback: :refresh_all_usage
+        )
       end
 
       search([:provider, :label])
@@ -57,6 +67,21 @@ if Code.ensure_loaded?(Incant) do
 
     def disable(%{id: id}, _assigns), do: set_enabled(id, false)
     def enable(%{id: id}, _assigns), do: set_enabled(id, true)
+
+    def refresh_usage(%{id: id}, _assigns) do
+      case LLMProxy.ProviderUsage.refresh_account(id) do
+        {:ok, _status} -> {:ok, Incant.ActionResult.refresh()}
+        {:error, :unsupported} -> {:error, "Usage tracking is not supported for this token"}
+        {:error, :unavailable} -> {:error, "Provider usage tracker is unavailable"}
+      end
+    end
+
+    def refresh_all_usage(_params, _assigns) do
+      case LLMProxy.ProviderUsage.refresh_all() do
+        {:ok, _status} -> {:ok, Incant.ActionResult.refresh()}
+        {:error, :unavailable} -> {:error, "Provider usage tracker is unavailable"}
+      end
+    end
 
     def remove(%{id: id}, _assigns) do
       case LLMProxy.Storage.remove_token(id) do

--- a/lib/llm_proxy/application.ex
+++ b/lib/llm_proxy/application.ex
@@ -32,7 +32,9 @@ defmodule LLMProxy.Application do
           LLMProxy.ConcurrencyLimiter,
           LLMProxy.Providers.CircuitBreaker,
           LLMProxy.Providers.Routing.RoundRobin,
-          LLMProxy.TokenPool.Server
+          LLMProxy.TokenPool.Server,
+          {Task.Supervisor, name: LLMProxy.ProviderUsage.TaskSupervisor, max_children: 1},
+          LLMProxy.ProviderUsage.Server
         ] ++ rpc_children() ++ http_children()
 
     opts = [strategy: :one_for_one, name: LLMProxy.Supervisor]

--- a/lib/llm_proxy/config.ex
+++ b/lib/llm_proxy/config.ex
@@ -4,6 +4,7 @@ defmodule LLMProxy.Config do
   """
 
   alias LLMProxy.Config.Catalog
+  alias LLMProxy.Config.ProviderUsage, as: ProviderUsageConfig
 
   def master_key, do: Application.get_env(:llm_proxy, :master_key)
 
@@ -352,7 +353,7 @@ defmodule LLMProxy.Config do
   defp validate_usage_paths!(provider, paths) when is_list(paths) do
     unless paths != [] and length(paths) <= 3 and
              length(paths) == MapSet.size(MapSet.new(paths)) and
-             Enum.all?(paths, &valid_usage_path?/1) do
+             Enum.all?(paths, &ProviderUsageConfig.valid_path?/1) do
       raise ArgumentError,
             "provider #{inspect(provider)} usage_paths must contain one through three distinct absolute origin paths"
     end
@@ -362,14 +363,6 @@ defmodule LLMProxy.Config do
     raise ArgumentError,
           "provider #{inspect(provider)} usage_paths must contain one through three distinct absolute origin paths"
   end
-
-  defp valid_usage_path?(path) when is_binary(path) do
-    byte_size(path) <= 256 and String.starts_with?(path, "/") and
-      not String.starts_with?(path, "//") and
-      not String.contains?(path, ["?", "#", "\\", "\r", "\n"])
-  end
-
-  defp valid_usage_path?(_path), do: false
 
   defp normalize_value(value) when is_list(value) do
     if Keyword.keyword?(value) do

--- a/lib/llm_proxy/config.ex
+++ b/lib/llm_proxy/config.ex
@@ -304,19 +304,72 @@ defmodule LLMProxy.Config do
     end
   end
 
-  defp normalize_providers(providers) when is_list(providers) do
+  defp normalize_providers(providers) when is_list(providers) or is_map(providers) do
     providers
-    |> Enum.map(fn {provider, config} -> {provider_name(provider), normalize_value(config)} end)
+    |> Enum.map(&normalize_provider/1)
     |> Map.new()
   end
 
-  defp normalize_providers(providers) when is_map(providers) do
-    providers
-    |> Enum.map(fn {provider, config} -> {provider_name(provider), normalize_value(config)} end)
-    |> Map.new()
+  defp normalize_providers(providers) do
+    raise ArgumentError, ":providers must be a keyword list or map, got: #{inspect(providers)}"
   end
 
-  defp normalize_providers(_providers), do: %{}
+  defp normalize_provider({provider, config}) do
+    case normalize_value(config) do
+      %{} = normalized ->
+        {provider_name(provider), validate_provider_usage!(provider, normalized)}
+
+      value ->
+        raise ArgumentError, "provider configuration must be a map, got: #{inspect(value)}"
+    end
+  end
+
+  defp validate_provider_usage!(provider, config) do
+    validate_usage_adapter!(provider, Map.get(config, :usage_adapter))
+    validate_usage_auth_scheme!(provider, Map.get(config, :usage_auth_scheme))
+    validate_usage_paths!(provider, Map.get(config, :usage_paths))
+    config
+  end
+
+  defp validate_usage_adapter!(_provider, nil), do: :ok
+  defp validate_usage_adapter!(_provider, "glm"), do: :ok
+
+  defp validate_usage_adapter!(provider, value) do
+    raise ArgumentError,
+          "provider #{inspect(provider)} usage_adapter must be \"glm\", got: #{inspect(value)}"
+  end
+
+  defp validate_usage_auth_scheme!(_provider, nil), do: :ok
+  defp validate_usage_auth_scheme!(_provider, value) when value in ["raw", "bearer"], do: :ok
+
+  defp validate_usage_auth_scheme!(provider, value) do
+    raise ArgumentError,
+          "provider #{inspect(provider)} usage_auth_scheme must be \"raw\" or \"bearer\", got: #{inspect(value)}"
+  end
+
+  defp validate_usage_paths!(_provider, nil), do: :ok
+
+  defp validate_usage_paths!(provider, paths) when is_list(paths) do
+    unless paths != [] and length(paths) <= 3 and
+             length(paths) == MapSet.size(MapSet.new(paths)) and
+             Enum.all?(paths, &valid_usage_path?/1) do
+      raise ArgumentError,
+            "provider #{inspect(provider)} usage_paths must contain one through three distinct absolute origin paths"
+    end
+  end
+
+  defp validate_usage_paths!(provider, _paths) do
+    raise ArgumentError,
+          "provider #{inspect(provider)} usage_paths must contain one through three distinct absolute origin paths"
+  end
+
+  defp valid_usage_path?(path) when is_binary(path) do
+    byte_size(path) <= 256 and String.starts_with?(path, "/") and
+      not String.starts_with?(path, "//") and
+      not String.contains?(path, ["?", "#", "\\", "\r", "\n"])
+  end
+
+  defp valid_usage_path?(_path), do: false
 
   defp normalize_value(value) when is_list(value) do
     if Keyword.keyword?(value) do

--- a/lib/llm_proxy/config.ex
+++ b/lib/llm_proxy/config.ex
@@ -22,6 +22,12 @@ defmodule LLMProxy.Config do
   @default_provider_connect_timeout_ms :timer.seconds(10)
   @default_provider_receive_timeout_ms :timer.minutes(10)
   @default_remote_timeout_ms :timer.seconds(30)
+  @default_provider_usage_refresh_interval_ms :timer.minutes(5)
+  @minimum_provider_usage_refresh_interval_ms :timer.minutes(1)
+  @maximum_provider_usage_refresh_interval_ms :timer.hours(1)
+  @default_provider_usage_request_timeout_ms :timer.seconds(10)
+  @minimum_provider_usage_request_timeout_ms :timer.seconds(1)
+  @maximum_provider_usage_request_timeout_ms :timer.seconds(30)
   @default_providers %{
     "anthropic" => %{
       base_url: "https://api.anthropic.com/v1",
@@ -155,7 +161,7 @@ defmodule LLMProxy.Config do
     do: provider |> provider_name() |> provider_config()
 
   def provider_config(provider) when is_binary(provider) do
-    configured = Application.get_env(:llm_proxy, :providers, %{}) |> normalize_providers()
+    configured = configured_providers()
     name = provider_name(provider)
     provider_config = Map.get(configured, name, %{})
 
@@ -163,6 +169,11 @@ defmodule LLMProxy.Config do
     |> Map.get(name, %{})
     |> deep_merge(provider_config)
     |> default_openrouter_referer(name, provider_config)
+  end
+
+  @doc false
+  def configured_providers do
+    Application.get_env(:llm_proxy, :providers, %{}) |> normalize_providers()
   end
 
   def provider_value(provider, key), do: provider_value(provider, key, nil)
@@ -222,6 +233,54 @@ defmodule LLMProxy.Config do
 
   def remote_timeout_ms,
     do: Application.get_env(:llm_proxy, :remote_timeout_ms, @default_remote_timeout_ms)
+
+  def provider_usage_auto_refresh? do
+    case Application.get_env(:llm_proxy, :provider_usage_auto_refresh, true) do
+      value when is_boolean(value) ->
+        value
+
+      value ->
+        raise ArgumentError,
+              ":provider_usage_auto_refresh must be a boolean, got: #{inspect(value)}"
+    end
+  end
+
+  def provider_usage_refresh_interval_ms do
+    bounded_integer!(
+      :provider_usage_refresh_interval_ms,
+      Application.get_env(
+        :llm_proxy,
+        :provider_usage_refresh_interval_ms,
+        @default_provider_usage_refresh_interval_ms
+      ),
+      @minimum_provider_usage_refresh_interval_ms,
+      @maximum_provider_usage_refresh_interval_ms
+    )
+  end
+
+  def provider_usage_request_timeout_ms do
+    bounded_integer!(
+      :provider_usage_request_timeout_ms,
+      Application.get_env(
+        :llm_proxy,
+        :provider_usage_request_timeout_ms,
+        @default_provider_usage_request_timeout_ms
+      ),
+      @minimum_provider_usage_request_timeout_ms,
+      @maximum_provider_usage_request_timeout_ms
+    )
+  end
+
+  def provider_usage_stale_after_ms do
+    default = max(provider_usage_refresh_interval_ms() * 2, :timer.minutes(10))
+
+    bounded_integer!(
+      :provider_usage_stale_after_ms,
+      Application.get_env(:llm_proxy, :provider_usage_stale_after_ms, default),
+      provider_usage_refresh_interval_ms(),
+      :timer.hours(24)
+    )
+  end
 
   def usage_window_4h_ms, do: @usage_window_4h_ms
   def usage_window_week_ms, do: @usage_window_week_ms
@@ -293,6 +352,9 @@ defmodule LLMProxy.Config do
     "title" => :title,
     "to" => :to,
     "token_pool" => :token_pool,
+    "usage_adapter" => :usage_adapter,
+    "usage_auth_scheme" => :usage_auth_scheme,
+    "usage_paths" => :usage_paths,
     "upstream_model" => :upstream_model,
     "weight" => :weight
   }
@@ -331,5 +393,14 @@ defmodule LLMProxy.Config do
         right_value
       end
     end)
+  end
+
+  defp bounded_integer!(_name, value, minimum, maximum)
+       when is_integer(value) and value >= minimum and value <= maximum,
+       do: value
+
+  defp bounded_integer!(name, value, minimum, maximum) do
+    raise ArgumentError,
+          ":#{name} must be an integer from #{minimum} through #{maximum}, got: #{inspect(value)}"
   end
 end

--- a/lib/llm_proxy/config/provider_usage.ex
+++ b/lib/llm_proxy/config/provider_usage.ex
@@ -3,10 +3,16 @@ defmodule LLMProxy.Config.ProviderUsage do
 
   @spec valid_path?(term()) :: boolean()
   def valid_path?(path) when is_binary(path) do
-    byte_size(path) <= 256 and String.starts_with?(path, "/") and
+    String.valid?(path) and byte_size(path) <= 256 and String.starts_with?(path, "/") and
       not String.starts_with?(path, "//") and
-      not String.contains?(path, ["?", "#", "\\", "\r", "\n"])
+      not String.contains?(path, ["?", "#", "\\"]) and valid_path_bytes?(path)
   end
 
   def valid_path?(_path), do: false
+
+  defp valid_path_bytes?(path) do
+    path
+    |> :binary.bin_to_list()
+    |> Enum.all?(&(&1 > 0x20 and &1 != 0x7F))
+  end
 end

--- a/lib/llm_proxy/config/provider_usage.ex
+++ b/lib/llm_proxy/config/provider_usage.ex
@@ -1,0 +1,12 @@
+defmodule LLMProxy.Config.ProviderUsage do
+  @moduledoc false
+
+  @spec valid_path?(term()) :: boolean()
+  def valid_path?(path) when is_binary(path) do
+    byte_size(path) <= 256 and String.starts_with?(path, "/") and
+      not String.starts_with?(path, "//") and
+      not String.contains?(path, ["?", "#", "\\", "\r", "\n"])
+  end
+
+  def valid_path?(_path), do: false
+end

--- a/lib/llm_proxy/config/toml.ex
+++ b/lib/llm_proxy/config/toml.ex
@@ -13,11 +13,12 @@ defmodule LLMProxy.Config.TOML do
   @type decoded :: keyword()
   @type reason :: Toml.reason()
 
-  @top_level_keys ~w(catalog models provider_tokens providers routing server storage telemetry)
+  @top_level_keys ~w(catalog models provider_tokens provider_usage providers routing server storage telemetry)
   @server_keys ~w(body_limit_bytes port public_url rpc_socket)
   @storage_keys ~w(database quackdb_endpoint quackdb_uri)
   @routing_keys ~w(max_retries provider_connect_timeout_ms replay_policy)
   @provider_token_keys ~w(allow_plaintext)
+  @provider_usage_keys ~w(auto_refresh refresh_interval_ms request_timeout_ms stale_after_ms)
   @telemetry_keys ~w(otlp_endpoint)
   @catalog_keys ~w(models public_models)
 
@@ -28,6 +29,9 @@ defmodule LLMProxy.Config.TOML do
     "beta" => :beta,
     "conversion_defaults" => :conversion_defaults,
     "http_referer" => :http_referer,
+    "usage_adapter" => :usage_adapter,
+    "usage_auth_scheme" => :usage_auth_scheme,
+    "usage_paths" => :usage_paths,
     "title" => :title,
     "token_pool" => :token_pool
   }
@@ -76,6 +80,7 @@ defmodule LLMProxy.Config.TOML do
       |> Keyword.merge(storage(data["storage"]))
       |> Keyword.merge(routing(data["routing"]))
       |> Keyword.merge(provider_tokens(data["provider_tokens"]))
+      |> Keyword.merge(provider_usage(data["provider_usage"]))
       |> put_if_present(:providers, providers(data["providers"]))
       |> put_if_present(:models, models(data["models"] || catalog[:models]))
       |> put_if_not_nil(:public_models, catalog[:public_models])
@@ -162,6 +167,34 @@ defmodule LLMProxy.Config.TOML do
 
   defp provider_tokens(_provider_tokens) do
     raise ArgumentError, "provider_tokens must be a TOML table"
+  end
+
+  defp provider_usage(nil), do: []
+
+  defp provider_usage(%{} = provider_usage) do
+    validate_keys!(provider_usage, @provider_usage_keys, "provider_usage")
+
+    refresh_interval =
+      bounded_integer(provider_usage, "refresh_interval_ms", 60_000, 3_600_000)
+
+    []
+    |> put_if_present(
+      :provider_usage_auto_refresh,
+      optional_boolean(provider_usage, "auto_refresh")
+    )
+    |> put_if_present(:provider_usage_refresh_interval_ms, refresh_interval)
+    |> put_if_present(
+      :provider_usage_request_timeout_ms,
+      bounded_integer(provider_usage, "request_timeout_ms", 1_000, 30_000)
+    )
+    |> put_if_present(
+      :provider_usage_stale_after_ms,
+      bounded_integer(provider_usage, "stale_after_ms", refresh_interval || 300_000, 86_400_000)
+    )
+  end
+
+  defp provider_usage(_provider_usage) do
+    raise ArgumentError, "provider_usage must be a TOML table"
   end
 
   defp telemetry(nil), do: []
@@ -308,6 +341,14 @@ defmodule LLMProxy.Config.TOML do
       :error -> nil
       {:ok, value} when is_integer(value) and value >= 0 -> value
       {:ok, _value} -> raise ArgumentError, "#{key} must be a non-negative integer"
+    end
+  end
+
+  defp bounded_integer(map, key, minimum, maximum) do
+    case Map.fetch(map, key) do
+      :error -> nil
+      {:ok, value} when is_integer(value) and value >= minimum and value <= maximum -> value
+      {:ok, _value} -> raise ArgumentError, "#{key} must be from #{minimum} through #{maximum}"
     end
   end
 

--- a/lib/llm_proxy/config/toml.ex
+++ b/lib/llm_proxy/config/toml.ex
@@ -303,7 +303,40 @@ defmodule LLMProxy.Config.TOML do
   defp normalize_value(:conversion_defaults, _value),
     do: raise(ArgumentError, "provider conversion_defaults must be a TOML table")
 
+  defp normalize_value(:usage_adapter, "glm"), do: "glm"
+
+  defp normalize_value(:usage_adapter, _value),
+    do: raise(ArgumentError, "provider usage_adapter must be glm")
+
+  defp normalize_value(:usage_auth_scheme, value) when value in ["raw", "bearer"], do: value
+
+  defp normalize_value(:usage_auth_scheme, _value),
+    do: raise(ArgumentError, "provider usage_auth_scheme must be raw or bearer")
+
+  defp normalize_value(:usage_paths, paths) when is_list(paths) do
+    if paths != [] and length(paths) <= 3 and length(paths) == MapSet.size(MapSet.new(paths)) and
+         Enum.all?(paths, &valid_usage_path?/1) do
+      paths
+    else
+      raise ArgumentError,
+            "provider usage_paths must contain one through three distinct absolute origin paths"
+    end
+  end
+
+  defp normalize_value(:usage_paths, _value) do
+    raise ArgumentError,
+          "provider usage_paths must contain one through three distinct absolute origin paths"
+  end
+
   defp normalize_value(_key, value), do: value
+
+  defp valid_usage_path?(path) when is_binary(path) do
+    byte_size(path) <= 256 and String.starts_with?(path, "/") and
+      not String.starts_with?(path, "//") and
+      not String.contains?(path, ["?", "#", "\\", "\r", "\n"])
+  end
+
+  defp valid_usage_path?(_path), do: false
 
   defp normalize_model_values(%{routing: routing} = model),
     do: %{model | routing: Model.routing_strategy!(routing)}

--- a/lib/llm_proxy/config/toml.ex
+++ b/lib/llm_proxy/config/toml.ex
@@ -8,6 +8,7 @@ defmodule LLMProxy.Config.TOML do
   """
 
   alias LLMProxy.Catalog.Model
+  alias LLMProxy.Config.ProviderUsage, as: ProviderUsageConfig
   alias LLMProxy.Storage.Repo.QuackDB
 
   @type decoded :: keyword()
@@ -315,7 +316,7 @@ defmodule LLMProxy.Config.TOML do
 
   defp normalize_value(:usage_paths, paths) when is_list(paths) do
     if paths != [] and length(paths) <= 3 and length(paths) == MapSet.size(MapSet.new(paths)) and
-         Enum.all?(paths, &valid_usage_path?/1) do
+         Enum.all?(paths, &ProviderUsageConfig.valid_path?/1) do
       paths
     else
       raise ArgumentError,
@@ -329,14 +330,6 @@ defmodule LLMProxy.Config.TOML do
   end
 
   defp normalize_value(_key, value), do: value
-
-  defp valid_usage_path?(path) when is_binary(path) do
-    byte_size(path) <= 256 and String.starts_with?(path, "/") and
-      not String.starts_with?(path, "//") and
-      not String.contains?(path, ["?", "#", "\\", "\r", "\n"])
-  end
-
-  defp valid_usage_path?(_path), do: false
 
   defp normalize_model_values(%{routing: routing} = model),
     do: %{model | routing: Model.routing_strategy!(routing)}

--- a/lib/llm_proxy/provider_usage.ex
+++ b/lib/llm_proxy/provider_usage.ex
@@ -1,0 +1,112 @@
+defmodule LLMProxy.ProviderUsage do
+  @moduledoc """
+  Live upstream usage-window state for configured provider accounts.
+
+  Provider credentials stay behind the provider-token codec boundary. Public
+  functions return only redacted account labels, quota values, timestamps, and
+  safe status text.
+  """
+
+  alias LLMProxy.ProviderUsage.{Server, Snapshot, Source}
+
+  @columns [
+    :provider,
+    :account,
+    :window,
+    :used_percent,
+    :remaining_percent,
+    :resets_at,
+    :availability,
+    :state,
+    :last_refresh,
+    :last_attempt,
+    :error
+  ]
+
+  @spec snapshots() :: [Snapshot.t()]
+  def snapshots do
+    if Process.whereis(Server) do
+      Server.snapshots()
+    else
+      []
+    end
+  end
+
+  @spec rows() :: %{columns: [atom()], rows: [map()]}
+  def rows do
+    %{columns: @columns, rows: Enum.flat_map(snapshots(), &snapshot_rows/1)}
+  end
+
+  @spec account_count() :: non_neg_integer()
+  def account_count, do: length(snapshots())
+
+  @spec available_count() :: non_neg_integer()
+  def available_count do
+    Enum.count(snapshots(), &(&1.availability in [:available, :limited]))
+  end
+
+  @spec attention_count() :: non_neg_integer()
+  def attention_count do
+    Enum.count(snapshots(), &(&1.state in [:stale, :error] or &1.availability == :unavailable))
+  end
+
+  @spec refresh_all() :: {:ok, :started | :already_refreshing} | {:error, :unavailable}
+  def refresh_all do
+    if Process.whereis(Server), do: Server.refresh_all(), else: {:error, :unavailable}
+  end
+
+  @spec refresh_account(integer() | String.t()) ::
+          {:ok, :started | :already_refreshing} | {:error, :unsupported | :unavailable}
+  def refresh_account(id) do
+    with {:ok, id} <- token_id(id),
+         true <- Source.supported_account?(id) do
+      if Process.whereis(Server) do
+        Server.refresh_account(id)
+      else
+        {:error, :unavailable}
+      end
+    else
+      _other -> {:error, :unsupported}
+    end
+  end
+
+  defp snapshot_rows(%Snapshot{windows: []} = snapshot), do: [snapshot_row(snapshot, nil)]
+
+  defp snapshot_rows(%Snapshot{} = snapshot) do
+    Enum.map(snapshot.windows, &snapshot_row(snapshot, &1))
+  end
+
+  defp snapshot_row(snapshot, window) do
+    %{
+      provider: snapshot.provider_label,
+      account: snapshot.account_label,
+      window: window && window.label,
+      used_percent: window && window.used_percent,
+      remaining_percent: window && window.remaining_percent,
+      resets_at: window && window.resets_at,
+      availability: humanize(snapshot.availability),
+      state: humanize(snapshot.state),
+      last_refresh: snapshot.refreshed_at,
+      last_attempt: snapshot.attempted_at,
+      error: snapshot.error
+    }
+  end
+
+  defp humanize(value) when is_atom(value) do
+    value
+    |> Atom.to_string()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp token_id(id) when is_integer(id) and id > 0, do: {:ok, id}
+
+  defp token_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {parsed, ""} when parsed > 0 -> {:ok, parsed}
+      _other -> :error
+    end
+  end
+
+  defp token_id(_id), do: :error
+end

--- a/lib/llm_proxy/provider_usage.ex
+++ b/lib/llm_proxy/provider_usage.ex
@@ -55,20 +55,21 @@ defmodule LLMProxy.ProviderUsage do
     if Process.whereis(Server), do: Server.refresh_all(), else: {:error, :unavailable}
   end
 
-  @spec refresh_account(integer() | String.t()) ::
+  @spec refresh_account(pos_integer()) ::
           {:ok, :started | :already_refreshing} | {:error, :unsupported | :unavailable}
-  def refresh_account(id) do
-    with {:ok, id} <- token_id(id),
-         true <- Source.supported_account?(id) do
+  def refresh_account(id) when is_integer(id) and id > 0 do
+    if Source.supported_account?(id) do
       if Process.whereis(Server) do
         Server.refresh_account(id)
       else
         {:error, :unavailable}
       end
     else
-      _other -> {:error, :unsupported}
+      {:error, :unsupported}
     end
   end
+
+  def refresh_account(_id), do: {:error, :unsupported}
 
   defp snapshot_rows(%Snapshot{windows: []} = snapshot), do: [snapshot_row(snapshot, nil)]
 
@@ -98,15 +99,4 @@ defmodule LLMProxy.ProviderUsage do
     |> String.replace("_", " ")
     |> String.capitalize()
   end
-
-  defp token_id(id) when is_integer(id) and id > 0, do: {:ok, id}
-
-  defp token_id(id) when is_binary(id) do
-    case Integer.parse(id) do
-      {parsed, ""} when parsed > 0 -> {:ok, parsed}
-      _other -> :error
-    end
-  end
-
-  defp token_id(_id), do: :error
 end

--- a/lib/llm_proxy/provider_usage/adapter.ex
+++ b/lib/llm_proxy/provider_usage/adapter.ex
@@ -1,0 +1,57 @@
+defmodule LLMProxy.ProviderUsage.Adapter do
+  @moduledoc "Provider-specific boundary for live usage acquisition."
+
+  alias LLMProxy.Provider.Credential
+  alias LLMProxy.ProviderUsage.{Result, Source}
+
+  @callback fetch(Credential.t(), Source.t()) ::
+              {:ok, Result.t()} | {:error, atom()}
+
+  @doc false
+  @spec collect(Enumerable.t(), (term() -> {:ok, term() | nil} | {:error, term()})) ::
+          {:ok, [term()]} | {:error, term()}
+  def collect(items, parser) when is_function(parser, 1) do
+    items
+    |> Enum.reduce_while({:ok, []}, fn item, {:ok, parsed} ->
+      case parser.(item) do
+        {:ok, nil} -> {:cont, {:ok, parsed}}
+        {:ok, value} -> {:cont, {:ok, [value | parsed]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> reverse_collected()
+  end
+
+  @doc false
+  @spec percent(term(), atom()) :: {:ok, number()} | {:error, atom()}
+  def percent(value, _error_reason) when is_number(value) and value >= 0 and value <= 100,
+    do: {:ok, rounded(value)}
+
+  def percent(_value, error_reason), do: {:error, error_reason}
+
+  @doc false
+  @spec remaining_percent(number()) :: number()
+  def remaining_percent(used), do: rounded(100 - used)
+
+  @doc false
+  @spec safe_plan(term()) :: String.t() | nil
+  def safe_plan(value) when is_binary(value) and byte_size(value) <= 40 do
+    if Regex.match?(~r/^[[:alnum:]_-]+$/u, value), do: value
+  end
+
+  def safe_plan(_value), do: nil
+
+  @doc false
+  @spec valid_header_value?(term()) :: boolean()
+  def valid_header_value?(value) when is_binary(value) and value != "" do
+    not String.contains?(value, ["\r", "\n"])
+  end
+
+  def valid_header_value?(_value), do: false
+
+  defp reverse_collected({:ok, parsed}), do: {:ok, Enum.reverse(parsed)}
+  defp reverse_collected({:error, _reason} = error), do: error
+
+  defp rounded(value) when is_integer(value), do: value
+  defp rounded(value), do: Float.round(value, 1)
+end

--- a/lib/llm_proxy/provider_usage/adapter.ex
+++ b/lib/llm_proxy/provider_usage/adapter.ex
@@ -8,6 +8,19 @@ defmodule LLMProxy.ProviderUsage.Adapter do
               {:ok, Result.t()} | {:error, term()}
 
   @doc false
+  @spec parse_json(term(), module(), (term() -> {:ok, Result.t()} | {:error, term()})) ::
+          {:ok, Result.t()} | {:error, term()}
+  def parse_json(body, response_module, parser)
+      when is_binary(body) and is_atom(response_module) and is_function(parser, 1) do
+    case response_module.decode(body) do
+      {:ok, response} -> parser.(response)
+      {:error, reason} -> {:error, {:invalid_response, reason}}
+    end
+  end
+
+  def parse_json(_body, _response_module, _parser), do: {:error, :invalid_response}
+
+  @doc false
   @spec collect(Enumerable.t(), (term() -> {:ok, term() | nil} | {:error, term()})) ::
           {:ok, [term()]} | {:error, term()}
   def collect(items, parser) when is_function(parser, 1) do

--- a/lib/llm_proxy/provider_usage/adapter.ex
+++ b/lib/llm_proxy/provider_usage/adapter.ex
@@ -5,7 +5,7 @@ defmodule LLMProxy.ProviderUsage.Adapter do
   alias LLMProxy.ProviderUsage.{Result, Source}
 
   @callback fetch(Credential.t(), Source.t()) ::
-              {:ok, Result.t()} | {:error, atom()}
+              {:ok, Result.t()} | {:error, term()}
 
   @doc false
   @spec collect(Enumerable.t(), (term() -> {:ok, term() | nil} | {:error, term()})) ::
@@ -34,12 +34,18 @@ defmodule LLMProxy.ProviderUsage.Adapter do
   def remaining_percent(used), do: rounded(100 - used)
 
   @doc false
-  @spec safe_plan(term()) :: String.t() | nil
-  def safe_plan(value) when is_binary(value) and byte_size(value) <= 40 do
-    if Regex.match?(~r/^[[:alnum:]_-]+$/u, value), do: value
+  @spec plan(term()) :: {:ok, String.t() | nil} | {:error, :invalid_plan}
+  def plan(nil), do: {:ok, nil}
+
+  def plan(value) when is_binary(value) and byte_size(value) <= 40 do
+    if Regex.match?(~r/^[[:alnum:]_-]+$/u, value) do
+      {:ok, value}
+    else
+      {:error, :invalid_plan}
+    end
   end
 
-  def safe_plan(_value), do: nil
+  def plan(_value), do: {:error, :invalid_plan}
 
   @doc false
   @spec valid_header_value?(term()) :: boolean()

--- a/lib/llm_proxy/provider_usage/adapters/codex.ex
+++ b/lib/llm_proxy/provider_usage/adapters/codex.ex
@@ -219,7 +219,6 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex do
 
   defp validate_optional_boolean(nil), do: :ok
   defp validate_optional_boolean(value) when is_boolean(value), do: :ok
-  defp validate_optional_boolean(_value), do: {:error, :invalid_limit_state}
 
   defp require_windows([]), do: {:error, :unsupported}
   defp require_windows(_windows), do: :ok

--- a/lib/llm_proxy/provider_usage/adapters/codex.ex
+++ b/lib/llm_proxy/provider_usage/adapters/codex.ex
@@ -26,14 +26,7 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex do
 
   @doc false
   @spec parse(String.t()) :: {:ok, Result.t()} | {:error, term()}
-  def parse(body) when is_binary(body) do
-    case Response.decode(body) do
-      {:ok, response} -> parse_response(response)
-      {:error, reason} -> {:error, {:invalid_response, reason}}
-    end
-  end
-
-  def parse(_body), do: {:error, :invalid_response}
+  def parse(body), do: Adapter.parse_json(body, Response, &parse_response/1)
 
   defp parse_response(%Current{rate_limit: limits} = response) do
     with :ok <- validate_current_state(response),

--- a/lib/llm_proxy/provider_usage/adapters/codex.ex
+++ b/lib/llm_proxy/provider_usage/adapters/codex.ex
@@ -1,0 +1,234 @@
+defmodule LLMProxy.ProviderUsage.Adapters.Codex do
+  @moduledoc "Live OpenAI Codex usage adapter."
+
+  @behaviour LLMProxy.ProviderUsage.Adapter
+
+  alias LLMProxy.Provider.Credential
+  alias LLMProxy.Providers.OpenAICodex
+  alias LLMProxy.ProviderUsage.{Adapter, HTTP, Result, Source, Window}
+  alias ReqLLM.Providers.OpenAICodex, as: ReqLLMOpenAICodex
+
+  @impl true
+  def fetch(%Credential{} = credential, %Source{} = source) do
+    with {:ok, credential} <- refresh_credential(credential),
+         :ok <- validate_credential(credential),
+         {:ok, body} <- HTTP.get(source, hd(source.usage_paths), headers(credential)) do
+      parse(body)
+    end
+  end
+
+  @doc false
+  @spec parse(map()) :: {:ok, Result.t()} | {:error, :invalid_response | :unsupported}
+  def parse(body) when is_map(body) do
+    with limits when is_map(limits) <- body["rate_limit"] || body["rate_limits"],
+         {:ok, windows} <- windows(limits),
+         false <- windows == [] do
+      {:ok,
+       %Result{
+         availability: availability(body, limits, windows),
+         windows: windows,
+         plan: Adapter.safe_plan(body["plan_type"] || body["planType"])
+       }}
+    else
+      nil -> {:error, :unsupported}
+      true -> {:error, :unsupported}
+      {:error, _reason} -> {:error, :invalid_response}
+      _other -> {:error, :invalid_response}
+    end
+  end
+
+  def parse(_body), do: {:error, :invalid_response}
+
+  defp refresh_credential(credential) do
+    refresh_fun = fn credentials, _opts ->
+      timeout = LLMProxy.Config.provider_usage_request_timeout_ms()
+
+      ReqLLMOpenAICodex.refresh_oauth_credentials(credentials,
+        oauth_http_options: [
+          connect_options: [timeout: timeout],
+          receive_timeout: timeout,
+          pool_timeout: timeout,
+          retry: false,
+          redirect: false
+        ]
+      )
+    end
+
+    case OpenAICodex.refresh_token_if_needed(credential, refresh_fun) do
+      {:ok, refreshed} -> {:ok, refreshed}
+      {:error, _reason} -> {:error, :token_refresh_failed}
+    end
+  end
+
+  defp validate_credential(%Credential{token: token, expires_at: expires_at}) do
+    cond do
+      not Adapter.valid_header_value?(token) -> {:error, :authentication_failed}
+      expired?(expires_at) -> {:error, :credential_expired}
+      true -> :ok
+    end
+  end
+
+  defp headers(credential) do
+    [
+      {"authorization", "Bearer #{credential.token}"},
+      {"accept", "application/json"},
+      {"content-type", "application/json"}
+    ]
+    |> maybe_account_header(account_id(credential))
+  end
+
+  defp account_id(%Credential{account_id: account_id})
+       when is_binary(account_id) and account_id != "",
+       do: account_id
+
+  defp account_id(%Credential{token: token}) do
+    ReqLLMOpenAICodex.account_id_from_token(token)
+  rescue
+    _error in [ArgumentError, FunctionClauseError] -> nil
+  end
+
+  defp maybe_account_header(headers, account_id) do
+    if Adapter.valid_header_value?(account_id) do
+      headers ++ [{"chatgpt-account-id", account_id}]
+    else
+      headers
+    end
+  end
+
+  defp windows(limits) do
+    [
+      {"Primary", limits["primary_window"] || limits["primary"]},
+      {"Secondary", limits["secondary_window"] || limits["secondary"]}
+    ]
+    |> Adapter.collect(fn {fallback_label, raw} ->
+      parse_window(raw, fallback_label)
+    end)
+  end
+
+  defp parse_window(nil, _fallback_label), do: {:ok, nil}
+
+  defp parse_window(raw, fallback_label) when is_map(raw) do
+    with {:ok, used_percent} <-
+           Adapter.percent(raw["used_percent"] || raw["usedPercent"], :invalid_percent),
+         {:ok, duration_seconds} <- duration_seconds(raw),
+         {:ok, resets_at} <- reset_time(raw) do
+      {:ok,
+       %Window{
+         label: window_label(duration_seconds, fallback_label),
+         used_percent: used_percent,
+         remaining_percent: Adapter.remaining_percent(used_percent),
+         resets_at: resets_at,
+         duration_seconds: duration_seconds
+       }}
+    end
+  end
+
+  defp parse_window(_raw, _fallback_label), do: {:error, :invalid_window}
+
+  defp duration_seconds(raw) do
+    cond do
+      positive_number?(raw["limit_window_seconds"]) ->
+        {:ok, trunc(raw["limit_window_seconds"])}
+
+      positive_number?(raw["window_minutes"]) ->
+        {:ok, trunc(raw["window_minutes"] * 60)}
+
+      positive_number?(raw["windowDurationMins"]) ->
+        {:ok, trunc(raw["windowDurationMins"] * 60)}
+
+      true ->
+        {:ok, nil}
+    end
+  end
+
+  defp reset_time(raw) do
+    value = raw["reset_at"] || raw["resets_at"] || raw["resetsAt"]
+    optional_datetime(value, :second)
+  end
+
+  defp optional_datetime(nil, _unit), do: {:ok, nil}
+
+  defp optional_datetime(value, unit) when is_integer(value) do
+    case DateTime.from_unix(value, unit) do
+      {:ok, datetime} -> {:ok, DateTime.truncate(datetime, :second)}
+      {:error, _reason} -> {:error, :invalid_datetime}
+    end
+  end
+
+  defp optional_datetime(value, unit) when is_float(value),
+    do: optional_datetime(trunc(value), unit)
+
+  defp optional_datetime(value, unit) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> optional_datetime(integer, unit)
+      _other -> iso8601_datetime(value)
+    end
+  end
+
+  defp optional_datetime(_value, _unit), do: {:error, :invalid_datetime}
+
+  defp iso8601_datetime(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.truncate(datetime, :second)}
+      {:error, _reason} -> {:error, :invalid_datetime}
+    end
+  end
+
+  defp availability(body, limits, windows) do
+    cond do
+      reached_type?(body["rate_limit_reached_type"] || body["rateLimitReachedType"]) ->
+        :unavailable
+
+      spend_control_reached?(body) ->
+        :unavailable
+
+      limits["allowed"] == false ->
+        :unavailable
+
+      limits["limit_reached"] == true ->
+        :unavailable
+
+      Enum.any?(windows, &(&1.used_percent >= 100)) ->
+        :unavailable
+
+      Enum.any?(windows, &(&1.used_percent >= 90)) ->
+        :limited
+
+      true ->
+        :available
+    end
+  end
+
+  defp reached_type?(value), do: value not in [nil, false]
+
+  defp spend_control_reached?(body) do
+    get_in(body, ["spend_control", "reached"]) == true or
+      body["spend_control_reached"] == true or body["spendControlReached"] == true
+  end
+
+  defp window_label(18_000, _fallback), do: "5 hour"
+  defp window_label(604_800, _fallback), do: "Weekly"
+  defp window_label(nil, fallback), do: fallback
+
+  defp window_label(seconds, _fallback) when rem(seconds, 604_800) == 0,
+    do: duration_label(div(seconds, 604_800), "week")
+
+  defp window_label(seconds, _fallback) when rem(seconds, 3_600) == 0,
+    do: duration_label(div(seconds, 3_600), "hour")
+
+  defp window_label(seconds, _fallback) when rem(seconds, 60) == 0,
+    do: duration_label(div(seconds, 60), "minute")
+
+  defp window_label(_seconds, fallback), do: fallback
+
+  defp duration_label(1, unit), do: "1 #{unit}"
+  defp duration_label(value, unit), do: "#{value} #{unit}s"
+
+  defp positive_number?(value), do: is_number(value) and value > 0
+
+  defp expired?(nil), do: false
+
+  defp expired?(%DateTime{} = expires_at) do
+    DateTime.compare(expires_at, DateTime.utc_now()) != :gt
+  end
+end

--- a/lib/llm_proxy/provider_usage/adapters/codex.ex
+++ b/lib/llm_proxy/provider_usage/adapters/codex.ex
@@ -5,7 +5,14 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex do
 
   alias LLMProxy.Provider.Credential
   alias LLMProxy.Providers.OpenAICodex
-  alias LLMProxy.ProviderUsage.{Adapter, HTTP, Result, Source, Window}
+  alias LLMProxy.ProviderUsage.Adapter
+  alias LLMProxy.ProviderUsage.Adapters.Codex.Response
+  alias LLMProxy.ProviderUsage.Adapters.Codex.Response.Current
+  alias LLMProxy.ProviderUsage.Adapters.Codex.Response.Legacy
+  alias LLMProxy.ProviderUsage.HTTP
+  alias LLMProxy.ProviderUsage.Result
+  alias LLMProxy.ProviderUsage.Source
+  alias LLMProxy.ProviderUsage.Window
   alias ReqLLM.Providers.OpenAICodex, as: ReqLLMOpenAICodex
 
   @impl true
@@ -18,26 +25,54 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex do
   end
 
   @doc false
-  @spec parse(map()) :: {:ok, Result.t()} | {:error, :invalid_response | :unsupported}
-  def parse(body) when is_map(body) do
-    with limits when is_map(limits) <- body["rate_limit"] || body["rate_limits"],
-         {:ok, windows} <- windows(limits),
-         false <- windows == [] do
-      {:ok,
-       %Result{
-         availability: availability(body, limits, windows),
-         windows: windows,
-         plan: Adapter.safe_plan(body["plan_type"] || body["planType"])
-       }}
-    else
-      nil -> {:error, :unsupported}
-      true -> {:error, :unsupported}
-      {:error, _reason} -> {:error, :invalid_response}
-      _other -> {:error, :invalid_response}
+  @spec parse(String.t()) :: {:ok, Result.t()} | {:error, term()}
+  def parse(body) when is_binary(body) do
+    case Response.decode(body) do
+      {:ok, response} -> parse_response(response)
+      {:error, reason} -> {:error, {:invalid_response, reason}}
     end
   end
 
   def parse(_body), do: {:error, :invalid_response}
+
+  defp parse_response(%Current{rate_limit: limits} = response) do
+    with :ok <- validate_current_state(response),
+         {:ok, plan} <- Adapter.plan(response.plan_type),
+         {:ok, windows} <-
+           windows(
+             [
+               {"Primary", limits.primary_window},
+               {"Secondary", limits.secondary_window}
+             ],
+             &current_window/2
+           ),
+         :ok <- require_windows(windows) do
+      {:ok,
+       %Result{
+         availability: current_availability(response, windows),
+         windows: windows,
+         plan: plan
+       }}
+    end
+  end
+
+  defp parse_response(%Legacy{rate_limits: limits} = response) do
+    with :ok <- validate_legacy_state(response),
+         {:ok, plan} <- Adapter.plan(response.plan_type),
+         {:ok, windows} <-
+           windows(
+             [{"Primary", limits.primary}, {"Secondary", limits.secondary}],
+             &legacy_window/2
+           ),
+         :ok <- require_windows(windows) do
+      {:ok,
+       %Result{
+         availability: legacy_availability(response, windows),
+         windows: windows,
+         plan: plan
+       }}
+    end
+  end
 
   defp refresh_credential(credential) do
     refresh_fun = fn credentials, _opts ->
@@ -95,23 +130,30 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex do
     end
   end
 
-  defp windows(limits) do
-    [
-      {"Primary", limits["primary_window"] || limits["primary"]},
-      {"Secondary", limits["secondary_window"] || limits["secondary"]}
-    ]
-    |> Adapter.collect(fn {fallback_label, raw} ->
-      parse_window(raw, fallback_label)
+  defp windows(raw_windows, parser) do
+    Adapter.collect(raw_windows, fn
+      {_label, nil} -> {:ok, nil}
+      {label, raw} -> parser.(raw, label)
     end)
   end
 
-  defp parse_window(nil, _fallback_label), do: {:ok, nil}
+  defp current_window(raw, fallback_label) do
+    with {:ok, duration_seconds} <-
+           exclusive_duration(raw.limit_window_seconds, raw.window_minutes),
+         {:ok, resets_at} <- exclusive_reset(raw.reset_at, raw.resets_at) do
+      window(raw.used_percent, duration_seconds, resets_at, fallback_label)
+    end
+  end
 
-  defp parse_window(raw, fallback_label) when is_map(raw) do
-    with {:ok, used_percent} <-
-           Adapter.percent(raw["used_percent"] || raw["usedPercent"], :invalid_percent),
-         {:ok, duration_seconds} <- duration_seconds(raw),
-         {:ok, resets_at} <- reset_time(raw) do
+  defp legacy_window(raw, fallback_label) do
+    with {:ok, duration_seconds} <- duration_from_minutes(raw.window_duration_mins),
+         {:ok, resets_at} <- unix_datetime(raw.resets_at) do
+      window(raw.used_percent, duration_seconds, resets_at, fallback_label)
+    end
+  end
+
+  defp window(used_percent, duration_seconds, resets_at, fallback_label) do
+    with {:ok, used_percent} <- Adapter.percent(used_percent, :invalid_percent) do
       {:ok,
        %Window{
          label: window_label(duration_seconds, fallback_label),
@@ -123,87 +165,95 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex do
     end
   end
 
-  defp parse_window(_raw, _fallback_label), do: {:error, :invalid_window}
+  defp exclusive_duration(nil, nil), do: {:ok, nil}
+  defp exclusive_duration(seconds, nil), do: positive_duration(seconds, 1)
+  defp exclusive_duration(nil, minutes), do: positive_duration(minutes, 60)
+  defp exclusive_duration(_seconds, _minutes), do: {:error, :ambiguous_duration}
 
-  defp duration_seconds(raw) do
-    cond do
-      positive_number?(raw["limit_window_seconds"]) ->
-        {:ok, trunc(raw["limit_window_seconds"])}
+  defp duration_from_minutes(nil), do: {:ok, nil}
+  defp duration_from_minutes(minutes), do: positive_duration(minutes, 60)
 
-      positive_number?(raw["window_minutes"]) ->
-        {:ok, trunc(raw["window_minutes"] * 60)}
+  defp positive_duration(value, multiplier) when is_number(value) and value > 0,
+    do: {:ok, trunc(value * multiplier)}
 
-      positive_number?(raw["windowDurationMins"]) ->
-        {:ok, trunc(raw["windowDurationMins"] * 60)}
+  defp positive_duration(_value, _multiplier), do: {:error, :invalid_duration}
 
-      true ->
-        {:ok, nil}
+  defp exclusive_reset(nil, nil), do: {:ok, nil}
+  defp exclusive_reset(value, nil), do: unix_datetime(value)
+  defp exclusive_reset(nil, value), do: unix_datetime(value)
+  defp exclusive_reset(_reset_at, _resets_at), do: {:error, :ambiguous_reset_time}
+
+  defp unix_datetime(nil), do: {:ok, nil}
+
+  defp unix_datetime(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> unix_datetime(integer)
+      _other -> {:error, :invalid_datetime}
     end
   end
 
-  defp reset_time(raw) do
-    value = raw["reset_at"] || raw["resets_at"] || raw["resetsAt"]
-    optional_datetime(value, :second)
-  end
-
-  defp optional_datetime(nil, _unit), do: {:ok, nil}
-
-  defp optional_datetime(value, unit) when is_integer(value) do
-    case DateTime.from_unix(value, unit) do
+  defp unix_datetime(value) when is_integer(value) and value >= 0 do
+    case DateTime.from_unix(value, :second) do
       {:ok, datetime} -> {:ok, DateTime.truncate(datetime, :second)}
       {:error, _reason} -> {:error, :invalid_datetime}
     end
   end
 
-  defp optional_datetime(value, unit) when is_float(value),
-    do: optional_datetime(trunc(value), unit)
+  defp unix_datetime(_value), do: {:error, :invalid_datetime}
 
-  defp optional_datetime(value, unit) when is_binary(value) do
-    case Integer.parse(value) do
-      {integer, ""} -> optional_datetime(integer, unit)
-      _other -> iso8601_datetime(value)
+  defp validate_current_state(%Current{} = response) do
+    with :ok <- validate_reached_type(response.rate_limit_reached_type) do
+      validate_optional_boolean(response.spend_control_reached)
     end
   end
 
-  defp optional_datetime(_value, _unit), do: {:error, :invalid_datetime}
-
-  defp iso8601_datetime(value) do
-    case DateTime.from_iso8601(value) do
-      {:ok, datetime, _offset} -> {:ok, DateTime.truncate(datetime, :second)}
-      {:error, _reason} -> {:error, :invalid_datetime}
+  defp validate_legacy_state(%Legacy{} = response) do
+    with :ok <- validate_reached_type(response.rate_limit_reached_type) do
+      validate_optional_boolean(response.spend_control_reached)
     end
   end
 
-  defp availability(body, limits, windows) do
+  defp validate_reached_type(nil), do: :ok
+  defp validate_reached_type(%{type: "rate_limit_reached"}), do: :ok
+  defp validate_reached_type(_value), do: {:error, :invalid_reached_type}
+
+  defp validate_optional_boolean(nil), do: :ok
+  defp validate_optional_boolean(value) when is_boolean(value), do: :ok
+  defp validate_optional_boolean(_value), do: {:error, :invalid_limit_state}
+
+  defp require_windows([]), do: {:error, :unsupported}
+  defp require_windows(_windows), do: :ok
+
+  defp current_availability(response, windows) do
+    limits = response.rate_limit
+
+    availability(
+      response.rate_limit_reached_type != nil or
+        match?(%{reached: true}, response.spend_control) or
+        response.spend_control_reached == true or
+        limits.allowed == false or limits.limit_reached == true,
+      windows
+    )
+  end
+
+  defp legacy_availability(response, windows) do
+    limits = response.rate_limits
+
+    availability(
+      response.rate_limit_reached_type != nil or response.spend_control_reached == true or
+        limits.allowed == false or limits.limit_reached == true,
+      windows
+    )
+  end
+
+  defp availability(true, _windows), do: :unavailable
+
+  defp availability(false, windows) do
     cond do
-      reached_type?(body["rate_limit_reached_type"] || body["rateLimitReachedType"]) ->
-        :unavailable
-
-      spend_control_reached?(body) ->
-        :unavailable
-
-      limits["allowed"] == false ->
-        :unavailable
-
-      limits["limit_reached"] == true ->
-        :unavailable
-
-      Enum.any?(windows, &(&1.used_percent >= 100)) ->
-        :unavailable
-
-      Enum.any?(windows, &(&1.used_percent >= 90)) ->
-        :limited
-
-      true ->
-        :available
+      Enum.any?(windows, &(&1.used_percent >= 100)) -> :unavailable
+      Enum.any?(windows, &(&1.used_percent >= 90)) -> :limited
+      true -> :available
     end
-  end
-
-  defp reached_type?(value), do: value not in [nil, false]
-
-  defp spend_control_reached?(body) do
-    get_in(body, ["spend_control", "reached"]) == true or
-      body["spend_control_reached"] == true or body["spendControlReached"] == true
   end
 
   defp window_label(18_000, _fallback), do: "5 hour"
@@ -223,8 +273,6 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex do
 
   defp duration_label(1, unit), do: "1 #{unit}"
   defp duration_label(value, unit), do: "#{value} #{unit}s"
-
-  defp positive_number?(value), do: is_number(value) and value > 0
 
   defp expired?(nil), do: false
 

--- a/lib/llm_proxy/provider_usage/adapters/codex/response.ex
+++ b/lib/llm_proxy/provider_usage/adapters/codex/response.ex
@@ -1,0 +1,176 @@
+defmodule LLMProxy.ProviderUsage.Adapters.Codex.Response do
+  @moduledoc false
+
+  defmodule Shape do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct rate_limit: :missing, rate_limits: :missing
+
+    @type t :: %__MODULE__{rate_limit: term(), rate_limits: term()}
+
+    codec(:rate_limits, as: "rateLimits")
+  end
+
+  defmodule ReachedType do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:type]
+
+    @type t :: %__MODULE__{type: String.t()}
+  end
+
+  defmodule SpendControl do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:reached]
+
+    @type t :: %__MODULE__{reached: boolean()}
+  end
+
+  defmodule CurrentWindow do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [
+      :used_percent,
+      :limit_window_seconds,
+      :window_minutes,
+      :reset_at,
+      :resets_at
+    ]
+
+    @type t :: %__MODULE__{
+            used_percent: number(),
+            limit_window_seconds: number() | nil,
+            window_minutes: number() | nil,
+            reset_at: integer() | nil,
+            resets_at: integer() | nil
+          }
+  end
+
+  defmodule CurrentLimits do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:allowed, :limit_reached, :primary_window, :secondary_window]
+
+    @type t :: %__MODULE__{
+            allowed: boolean() | nil,
+            limit_reached: boolean() | nil,
+            primary_window: CurrentWindow.t() | nil,
+            secondary_window: CurrentWindow.t() | nil
+          }
+  end
+
+  defmodule Current do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [
+      :plan_type,
+      :rate_limit,
+      :rate_limit_reached_type,
+      :spend_control,
+      :spend_control_reached
+    ]
+
+    @type t :: %__MODULE__{
+            plan_type: String.t() | nil,
+            rate_limit: CurrentLimits.t(),
+            rate_limit_reached_type: ReachedType.t() | nil,
+            spend_control: SpendControl.t() | nil,
+            spend_control_reached: boolean() | nil
+          }
+  end
+
+  defmodule LegacyWindow do
+    @moduledoc false
+
+    use JSONCodec, case: :camel, strict: true, fast_path: :json
+
+    defstruct [:used_percent, :window_duration_mins, :resets_at]
+
+    @type t :: %__MODULE__{
+            used_percent: number(),
+            window_duration_mins: number() | nil,
+            resets_at: integer() | nil
+          }
+
+    codec(:resets_at, cast: :integer_timestamp)
+
+    def integer_timestamp(value) when is_integer(value), do: value
+
+    def integer_timestamp(value) when is_binary(value) do
+      case Integer.parse(value) do
+        {integer, ""} -> integer
+        _other -> raise ArgumentError, "invalid legacy Codex reset timestamp"
+      end
+    end
+  end
+
+  defmodule LegacyLimits do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:allowed, :limit_reached, :primary, :secondary]
+
+    @type t :: %__MODULE__{
+            allowed: boolean() | nil,
+            limit_reached: boolean() | nil,
+            primary: LegacyWindow.t() | nil,
+            secondary: LegacyWindow.t() | nil
+          }
+  end
+
+  defmodule Legacy do
+    @moduledoc false
+
+    use JSONCodec, case: :camel, strict: true, fast_path: :json
+
+    defstruct [
+      :plan_type,
+      :rate_limits,
+      :rate_limit_reached_type,
+      :spend_control_reached
+    ]
+
+    @type t :: %__MODULE__{
+            plan_type: String.t() | nil,
+            rate_limits: LegacyLimits.t(),
+            rate_limit_reached_type: ReachedType.t() | nil,
+            spend_control_reached: boolean() | nil
+          }
+  end
+
+  @type t :: Current.t() | Legacy.t()
+
+  @spec decode(String.t()) :: {:ok, t()} | {:error, term()}
+  def decode(json) when is_binary(json) do
+    with {:ok, shape} <- Shape.decode(json) do
+      decode_shape(json, shape)
+    end
+  end
+
+  defp decode_shape(json, %Shape{rate_limit: rate_limit, rate_limits: :missing})
+       when rate_limit != :missing,
+       do: Current.decode(json)
+
+  defp decode_shape(json, %Shape{rate_limit: :missing, rate_limits: rate_limits})
+       when rate_limits != :missing,
+       do: Legacy.decode(json)
+
+  defp decode_shape(_json, %Shape{rate_limit: :missing, rate_limits: :missing}),
+    do: {:error, :unsupported_shape}
+
+  defp decode_shape(_json, %Shape{}), do: {:error, :ambiguous_shape}
+end

--- a/lib/llm_proxy/provider_usage/adapters/codex/response.ex
+++ b/lib/llm_proxy/provider_usage/adapters/codex/response.ex
@@ -107,14 +107,17 @@ defmodule LLMProxy.ProviderUsage.Adapters.Codex.Response do
 
     codec(:resets_at, cast: :integer_timestamp)
 
+    def integer_timestamp(nil), do: nil
     def integer_timestamp(value) when is_integer(value), do: value
 
     def integer_timestamp(value) when is_binary(value) do
       case Integer.parse(value) do
         {integer, ""} -> integer
-        _other -> raise ArgumentError, "invalid legacy Codex reset timestamp"
+        _other -> :invalid_timestamp
       end
     end
+
+    def integer_timestamp(_value), do: :invalid_timestamp
   end
 
   defmodule LegacyLimits do

--- a/lib/llm_proxy/provider_usage/adapters/glm.ex
+++ b/lib/llm_proxy/provider_usage/adapters/glm.ex
@@ -27,14 +27,7 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLM do
 
   @doc false
   @spec parse(String.t()) :: {:ok, Result.t()} | {:error, term()}
-  def parse(body) when is_binary(body) do
-    case Response.decode(body) do
-      {:ok, response} -> parse_response(response)
-      {:error, reason} -> {:error, {:invalid_response, reason}}
-    end
-  end
-
-  def parse(_body), do: {:error, :invalid_response}
+  def parse(body), do: Adapter.parse_json(body, Response, &parse_response/1)
 
   defp parse_response(%Authentication{code: code}) when code in [401, 403],
     do: {:error, :authentication_failed}

--- a/lib/llm_proxy/provider_usage/adapters/glm.ex
+++ b/lib/llm_proxy/provider_usage/adapters/glm.ex
@@ -1,0 +1,147 @@
+defmodule LLMProxy.ProviderUsage.Adapters.GLM do
+  @moduledoc "Live Z.AI GLM Coding Plan usage adapter."
+
+  @behaviour LLMProxy.ProviderUsage.Adapter
+
+  alias LLMProxy.Provider.Credential
+  alias LLMProxy.ProviderUsage.{Adapter, HTTP, Result, Source, Window}
+
+  @supported_limit_types ~w(TOKENS_LIMIT CREDIT_LIMIT TIME_LIMIT)
+
+  @impl true
+  def fetch(%Credential{} = credential, %Source{} = source) do
+    with :ok <- validate_credential(credential) do
+      fetch_paths(source.usage_paths, credential, source)
+    end
+  end
+
+  @doc false
+  @spec parse(map()) :: {:ok, Result.t()} | {:error, atom()}
+  def parse(%{"code" => code}) when code in [401, 403], do: {:error, :authentication_failed}
+
+  def parse(%{"success" => false}), do: {:error, :unsupported}
+
+  def parse(body) when is_map(body) do
+    data = if is_map(body["data"]), do: body["data"], else: body
+
+    with limits when is_list(limits) <- data["limits"],
+         {:ok, windows} <- parse_windows(limits),
+         false <- windows == [] do
+      {:ok,
+       %Result{
+         availability: availability(windows),
+         windows: Enum.sort_by(windows, &(&1.duration_seconds || 9_999_999_999)),
+         plan: Adapter.safe_plan(data["level"])
+       }}
+    else
+      nil -> {:error, :unsupported}
+      true -> {:error, :unsupported}
+      {:error, reason} -> {:error, reason}
+      _other -> {:error, :invalid_response}
+    end
+  end
+
+  def parse(_body), do: {:error, :invalid_response}
+
+  defp fetch_paths([path | rest], credential, source) do
+    result =
+      with {:ok, body} <- HTTP.get(source, path, headers(credential, source.auth_scheme)) do
+        parse(body)
+      end
+
+    case result do
+      {:error, reason} when reason in [:authentication_failed, :not_found] and rest != [] ->
+        fetch_paths(rest, credential, source)
+
+      other ->
+        other
+    end
+  end
+
+  defp fetch_paths([], _credential, _source), do: {:error, :unsupported}
+
+  defp validate_credential(%Credential{token: token}) do
+    if Adapter.valid_header_value?(token), do: :ok, else: {:error, :authentication_failed}
+  end
+
+  defp headers(credential, auth_scheme) do
+    authorization =
+      case auth_scheme do
+        :bearer -> "Bearer #{credential.token}"
+        :raw -> credential.token
+      end
+
+    [
+      {"authorization", authorization},
+      {"accept", "application/json"},
+      {"accept-language", "en-US,en"},
+      {"content-type", "application/json"}
+    ]
+  end
+
+  defp parse_windows(limits) do
+    limits
+    |> Enum.filter(&(is_map(&1) and &1["type"] in @supported_limit_types))
+    |> Adapter.collect(&parse_window/1)
+  end
+
+  defp parse_window(raw) do
+    with {:ok, used_percent} <- Adapter.percent(raw["percentage"], :invalid_response),
+         {:ok, resets_at} <- reset_time(raw["nextResetTime"]) do
+      duration_seconds = duration_seconds(raw["unit"], raw["number"])
+
+      {:ok,
+       %Window{
+         label: window_label(raw["type"], duration_seconds),
+         used_percent: used_percent,
+         remaining_percent: Adapter.remaining_percent(used_percent),
+         resets_at: resets_at,
+         duration_seconds: duration_seconds
+       }}
+    end
+  end
+
+  defp duration_seconds(3, number) when is_number(number) and number > 0,
+    do: trunc(number * 3_600)
+
+  defp duration_seconds(6, number) when is_number(number) and number > 0,
+    do: trunc(number * 604_800)
+
+  defp duration_seconds(_unit, _number), do: nil
+
+  defp window_label(_type, 18_000), do: "5 hour"
+  defp window_label(_type, 604_800), do: "Weekly"
+  defp window_label("TIME_LIMIT", _duration), do: "Monthly tools"
+  defp window_label("CREDIT_LIMIT", _duration), do: "Credit limit"
+  defp window_label(_type, _duration), do: "Token limit"
+
+  defp reset_time(nil), do: {:ok, nil}
+
+  defp reset_time(value) when is_integer(value) do
+    unit = if value >= 100_000_000_000, do: :millisecond, else: :second
+
+    case DateTime.from_unix(value, unit) do
+      {:ok, datetime} -> {:ok, DateTime.truncate(datetime, :second)}
+      {:error, _reason} -> {:error, :invalid_response}
+    end
+  end
+
+  defp reset_time(value) when is_float(value), do: reset_time(trunc(value))
+
+  defp reset_time(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> reset_time(integer)
+      _other -> {:error, :invalid_response}
+    end
+  end
+
+  defp reset_time(_value), do: {:error, :invalid_response}
+
+  defp availability(windows) do
+    cond do
+      Enum.any?(windows, &(&1.used_percent >= 100)) -> :unavailable
+      Enum.any?(windows, &(&1.used_percent >= 90)) -> :limited
+      true -> :available
+    end
+  end
+end

--- a/lib/llm_proxy/provider_usage/adapters/glm.ex
+++ b/lib/llm_proxy/provider_usage/adapters/glm.ex
@@ -33,6 +33,10 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLM do
     do: {:error, :authentication_failed}
 
   defp parse_response(%Authentication{}), do: {:error, :invalid_response}
+
+  defp parse_response(%Failure{code: code}) when code in [401, 403],
+    do: {:error, :authentication_failed}
+
   defp parse_response(%Failure{success: false}), do: {:error, :unsupported}
   defp parse_response(%Failure{}), do: {:error, :invalid_response}
 

--- a/lib/llm_proxy/provider_usage/adapters/glm.ex
+++ b/lib/llm_proxy/provider_usage/adapters/glm.ex
@@ -4,7 +4,17 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLM do
   @behaviour LLMProxy.ProviderUsage.Adapter
 
   alias LLMProxy.Provider.Credential
-  alias LLMProxy.ProviderUsage.{Adapter, HTTP, Result, Source, Window}
+  alias LLMProxy.ProviderUsage.Adapter
+  alias LLMProxy.ProviderUsage.Adapters.GLM.Response
+  alias LLMProxy.ProviderUsage.Adapters.GLM.Response.Authentication
+  alias LLMProxy.ProviderUsage.Adapters.GLM.Response.Data
+  alias LLMProxy.ProviderUsage.Adapters.GLM.Response.Envelope
+  alias LLMProxy.ProviderUsage.Adapters.GLM.Response.Failure
+  alias LLMProxy.ProviderUsage.Adapters.GLM.Response.Limit
+  alias LLMProxy.ProviderUsage.HTTP
+  alias LLMProxy.ProviderUsage.Result
+  alias LLMProxy.ProviderUsage.Source
+  alias LLMProxy.ProviderUsage.Window
 
   @supported_limit_types ~w(TOKENS_LIMIT CREDIT_LIMIT TIME_LIMIT)
 
@@ -16,32 +26,45 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLM do
   end
 
   @doc false
-  @spec parse(map()) :: {:ok, Result.t()} | {:error, atom()}
-  def parse(%{"code" => code}) when code in [401, 403], do: {:error, :authentication_failed}
+  @spec parse(String.t()) :: {:ok, Result.t()} | {:error, term()}
+  def parse(body) when is_binary(body) do
+    case Response.decode(body) do
+      {:ok, response} -> parse_response(response)
+      {:error, reason} -> {:error, {:invalid_response, reason}}
+    end
+  end
 
-  def parse(%{"success" => false}), do: {:error, :unsupported}
+  def parse(_body), do: {:error, :invalid_response}
 
-  def parse(body) when is_map(body) do
-    data = if is_map(body["data"]), do: body["data"], else: body
+  defp parse_response(%Authentication{code: code}) when code in [401, 403],
+    do: {:error, :authentication_failed}
 
-    with limits when is_list(limits) <- data["limits"],
-         {:ok, windows} <- parse_windows(limits),
+  defp parse_response(%Authentication{}), do: {:error, :invalid_response}
+  defp parse_response(%Failure{success: false}), do: {:error, :unsupported}
+  defp parse_response(%Failure{}), do: {:error, :invalid_response}
+
+  defp parse_response(%Envelope{code: code}) when code in [401, 403],
+    do: {:error, :authentication_failed}
+
+  defp parse_response(%Envelope{success: false}), do: {:error, :unsupported}
+  defp parse_response(%Envelope{data: data}), do: parse_data(data)
+  defp parse_response(%Data{} = data), do: parse_data(data)
+
+  defp parse_data(%Data{limits: limits} = data) do
+    with {:ok, plan} <- Adapter.plan(data.level),
+         {:ok, windows} <- Adapter.collect(limits, &parse_window/1),
          false <- windows == [] do
       {:ok,
        %Result{
          availability: availability(windows),
          windows: Enum.sort_by(windows, &(&1.duration_seconds || 9_999_999_999)),
-         plan: Adapter.safe_plan(data["level"])
+         plan: plan
        }}
     else
-      nil -> {:error, :unsupported}
       true -> {:error, :unsupported}
       {:error, reason} -> {:error, reason}
-      _other -> {:error, :invalid_response}
     end
   end
-
-  def parse(_body), do: {:error, :invalid_response}
 
   defp fetch_paths([path | rest], credential, source) do
     result =
@@ -79,20 +102,13 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLM do
     ]
   end
 
-  defp parse_windows(limits) do
-    limits
-    |> Enum.filter(&(is_map(&1) and &1["type"] in @supported_limit_types))
-    |> Adapter.collect(&parse_window/1)
-  end
-
-  defp parse_window(raw) do
-    with {:ok, used_percent} <- Adapter.percent(raw["percentage"], :invalid_response),
-         {:ok, resets_at} <- reset_time(raw["nextResetTime"]) do
-      duration_seconds = duration_seconds(raw["unit"], raw["number"])
-
+  defp parse_window(%Limit{type: type} = raw) when type in @supported_limit_types do
+    with {:ok, used_percent} <- Adapter.percent(raw.percentage, :invalid_response),
+         {:ok, resets_at} <- reset_time(raw.next_reset_time),
+         {:ok, duration_seconds} <- duration_seconds(raw.unit, raw.number) do
       {:ok,
        %Window{
-         label: window_label(raw["type"], duration_seconds),
+         label: window_label(type, duration_seconds),
          used_percent: used_percent,
          remaining_percent: Adapter.remaining_percent(used_percent),
          resets_at: resets_at,
@@ -101,37 +117,32 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLM do
     end
   end
 
+  defp parse_window(%Limit{}), do: {:error, :unknown_limit_type}
+
+  defp duration_seconds(nil, nil), do: {:ok, nil}
+
   defp duration_seconds(3, number) when is_number(number) and number > 0,
-    do: trunc(number * 3_600)
+    do: {:ok, trunc(number * 3_600)}
 
   defp duration_seconds(6, number) when is_number(number) and number > 0,
-    do: trunc(number * 604_800)
+    do: {:ok, trunc(number * 604_800)}
 
-  defp duration_seconds(_unit, _number), do: nil
+  defp duration_seconds(_unit, _number), do: {:error, :invalid_duration}
 
   defp window_label(_type, 18_000), do: "5 hour"
   defp window_label(_type, 604_800), do: "Weekly"
   defp window_label("TIME_LIMIT", _duration), do: "Monthly tools"
   defp window_label("CREDIT_LIMIT", _duration), do: "Credit limit"
-  defp window_label(_type, _duration), do: "Token limit"
+  defp window_label("TOKENS_LIMIT", _duration), do: "Token limit"
 
   defp reset_time(nil), do: {:ok, nil}
 
-  defp reset_time(value) when is_integer(value) do
+  defp reset_time(value) when is_integer(value) and value >= 0 do
     unit = if value >= 100_000_000_000, do: :millisecond, else: :second
 
     case DateTime.from_unix(value, unit) do
       {:ok, datetime} -> {:ok, DateTime.truncate(datetime, :second)}
       {:error, _reason} -> {:error, :invalid_response}
-    end
-  end
-
-  defp reset_time(value) when is_float(value), do: reset_time(trunc(value))
-
-  defp reset_time(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {integer, ""} -> reset_time(integer)
-      _other -> {:error, :invalid_response}
     end
   end
 

--- a/lib/llm_proxy/provider_usage/adapters/glm/response.ex
+++ b/lib/llm_proxy/provider_usage/adapters/glm/response.ex
@@ -1,0 +1,118 @@
+defmodule LLMProxy.ProviderUsage.Adapters.GLM.Response do
+  @moduledoc false
+
+  defmodule Shape do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct data: :missing, limits: :missing, code: :missing, success: :missing
+
+    @type t :: %__MODULE__{
+            data: term(),
+            limits: term(),
+            code: term(),
+            success: term()
+          }
+  end
+
+  defmodule Limit do
+    @moduledoc false
+
+    use JSONCodec, case: :camel, strict: true, fast_path: :json
+
+    defstruct [:type, :unit, :number, :percentage, :next_reset_time]
+
+    @type t :: %__MODULE__{
+            type: String.t(),
+            unit: integer() | nil,
+            number: number() | nil,
+            percentage: number(),
+            next_reset_time: integer() | nil
+          }
+  end
+
+  defmodule Data do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:level, :limits]
+
+    @type t :: %__MODULE__{level: String.t() | nil, limits: [Limit.t()]}
+  end
+
+  defmodule Envelope do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:code, :success, :data]
+
+    @type t :: %__MODULE__{
+            code: integer() | nil,
+            success: boolean() | nil,
+            data: Data.t()
+          }
+  end
+
+  defmodule Authentication do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:code]
+
+    @type t :: %__MODULE__{code: integer()}
+  end
+
+  defmodule Failure do
+    @moduledoc false
+
+    use JSONCodec, strict: true, fast_path: :json
+
+    defstruct [:code, :success]
+
+    @type t :: %__MODULE__{code: integer() | nil, success: boolean()}
+  end
+
+  @type t :: Envelope.t() | Data.t() | Authentication.t() | Failure.t()
+
+  @spec decode(String.t()) :: {:ok, t()} | {:error, term()}
+  def decode(json) when is_binary(json) do
+    with {:ok, shape} <- Shape.decode(json) do
+      decode_shape(json, shape)
+    end
+  end
+
+  defp decode_shape(json, %Shape{data: data, limits: :missing}) when data != :missing,
+    do: Envelope.decode(json)
+
+  defp decode_shape(json, %Shape{
+         data: :missing,
+         limits: limits,
+         code: :missing,
+         success: :missing
+       })
+       when limits != :missing,
+       do: Data.decode(json)
+
+  defp decode_shape(json, %Shape{
+         data: :missing,
+         limits: :missing,
+         code: code,
+         success: :missing
+       })
+       when code != :missing,
+       do: Authentication.decode(json)
+
+  defp decode_shape(json, %Shape{
+         data: :missing,
+         limits: :missing,
+         success: success
+       })
+       when success != :missing,
+       do: Failure.decode(json)
+
+  defp decode_shape(_json, %Shape{}), do: {:error, :unsupported_or_ambiguous_shape}
+end

--- a/lib/llm_proxy/provider_usage/http.ex
+++ b/lib/llm_proxy/provider_usage/http.ex
@@ -1,0 +1,61 @@
+defmodule LLMProxy.ProviderUsage.HTTP do
+  @moduledoc false
+
+  alias LLMProxy.ProviderUsage.Source
+
+  @spec get(Source.t(), String.t(), [{String.t(), String.t()}]) ::
+          {:ok, map()} | {:error, atom()}
+  def get(%Source{} = source, path, headers) do
+    with {:ok, url} <- url(source.base_url, path) do
+      timeout = LLMProxy.Config.provider_usage_request_timeout_ms()
+
+      request =
+        LLMProxy.HTTP.new(
+          url: url,
+          headers: headers,
+          connect_options: [timeout: timeout],
+          receive_timeout: timeout,
+          finch: [pool_timeout: timeout],
+          retry: false,
+          redirect: false
+        )
+
+      case Req.get(request) do
+        {:ok, %{status: 200, body: body}} when is_map(body) -> {:ok, body}
+        {:ok, %{status: 200}} -> {:error, :invalid_response}
+        {:ok, %{status: status}} -> {:error, status_error(status)}
+        {:error, exception} -> {:error, exception_error(exception)}
+      end
+    end
+  end
+
+  defp url(base_url, path) when is_binary(base_url) and is_binary(path) do
+    case URI.parse(base_url) do
+      %URI{scheme: "https", host: host, userinfo: nil} = uri
+      when is_binary(host) and host != "" ->
+        {:ok,
+         uri
+         |> Map.put(:path, path)
+         |> Map.put(:query, nil)
+         |> Map.put(:fragment, nil)
+         |> URI.to_string()}
+
+      _other ->
+        {:error, :invalid_configuration}
+    end
+  end
+
+  defp url(_base_url, _path), do: {:error, :invalid_configuration}
+
+  defp status_error(status) when status in [401, 403], do: :authentication_failed
+  defp status_error(404), do: :not_found
+  defp status_error(408), do: :timeout
+  defp status_error(429), do: :rate_limited
+  defp status_error(status) when status in 500..599, do: :unavailable
+  defp status_error(_status), do: :invalid_response
+
+  defp exception_error(%{reason: reason}) when reason in [:timeout, :connect_timeout],
+    do: :timeout
+
+  defp exception_error(_exception), do: :unavailable
+end

--- a/lib/llm_proxy/provider_usage/http.ex
+++ b/lib/llm_proxy/provider_usage/http.ex
@@ -3,8 +3,12 @@ defmodule LLMProxy.ProviderUsage.HTTP do
 
   alias LLMProxy.ProviderUsage.Source
 
+  @max_response_bytes 256_000
+  @response_state_key :llm_proxy_provider_usage_body
+  @response_too_large_key :llm_proxy_provider_usage_body_too_large
+
   @spec get(Source.t(), String.t(), [{String.t(), String.t()}]) ::
-          {:ok, map()} | {:error, atom()}
+          {:ok, String.t()} | {:error, atom()}
   def get(%Source{} = source, path, headers) do
     with {:ok, url} <- url(source.base_url, path) do
       timeout = LLMProxy.Config.provider_usage_request_timeout_ms()
@@ -17,15 +21,43 @@ defmodule LLMProxy.ProviderUsage.HTTP do
           receive_timeout: timeout,
           finch: [pool_timeout: timeout],
           retry: false,
-          redirect: false
+          redirect: false,
+          decode_body: false,
+          into: &collect_body/2
         )
 
       case Req.get(request) do
-        {:ok, %{status: 200, body: body}} when is_map(body) -> {:ok, body}
-        {:ok, %{status: 200}} -> {:error, :invalid_response}
-        {:ok, %{status: status}} -> {:error, status_error(status)}
-        {:error, exception} -> {:error, exception_error(exception)}
+        {:ok, %{private: %{@response_too_large_key => true}}} ->
+          {:error, :response_too_large}
+
+        {:ok, %{status: 200} = response} ->
+          response_body(response)
+
+        {:ok, %{status: status}} ->
+          {:error, status_error(status)}
+
+        {:error, exception} ->
+          {:error, exception_error(exception)}
       end
+    end
+  end
+
+  defp collect_body({:data, data}, {request, response}) when is_binary(data) do
+    {size, chunks} = Map.get(response.private, @response_state_key, {0, []})
+    size = size + byte_size(data)
+
+    if size > @max_response_bytes do
+      response = put_in(response.private[@response_too_large_key], true)
+      {:halt, {request, response}}
+    else
+      response = put_in(response.private[@response_state_key], {size, [data | chunks]})
+      {:cont, {request, response}}
+    end
+  end
+
+  defp response_body(response) do
+    case Map.get(response.private, @response_state_key, {0, []}) do
+      {_size, chunks} -> {:ok, chunks |> Enum.reverse() |> IO.iodata_to_binary()}
     end
   end
 

--- a/lib/llm_proxy/provider_usage/loader.ex
+++ b/lib/llm_proxy/provider_usage/loader.ex
@@ -93,6 +93,8 @@ defmodule LLMProxy.ProviderUsage.Loader do
   defp safe_error(:unavailable), do: "Provider usage API is unavailable"
   defp safe_error(:not_found), do: "Provider usage API is unsupported"
   defp safe_error(:invalid_response), do: "Provider returned invalid usage data"
+  defp safe_error(:response_too_large), do: "Provider returned invalid usage data"
+  defp safe_error({:invalid_response, _reason}), do: "Provider returned invalid usage data"
   defp safe_error(_reason), do: "Provider usage refresh failed"
 
   defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)

--- a/lib/llm_proxy/provider_usage/loader.ex
+++ b/lib/llm_proxy/provider_usage/loader.ex
@@ -1,0 +1,99 @@
+defmodule LLMProxy.ProviderUsage.Loader do
+  @moduledoc false
+
+  alias LLMProxy.Provider.TokenCodec
+  alias LLMProxy.ProviderUsage.{Result, Snapshot, Source}
+
+  @spec refresh(:all | {:account, integer()}) :: [Snapshot.t()]
+  def refresh(scope) do
+    Source.accounts()
+    |> select(scope)
+    |> Enum.map(&refresh_source/1)
+  end
+
+  defp select(sources, :all), do: sources
+  defp select(sources, {:account, id}), do: Enum.filter(sources, &(&1.token_id == id))
+
+  defp refresh_source(%Source{} = source) do
+    do_refresh_source(source)
+  catch
+    _kind, _reason -> error_snapshot(source, now(), :refresh_failed)
+  end
+
+  defp do_refresh_source(%Source{stored_token: %{enabled: false}} = source) do
+    snapshot(source,
+      availability: :unavailable,
+      state: :disabled,
+      error: "Provider token is disabled"
+    )
+  end
+
+  defp do_refresh_source(%Source{config_error: error} = source) when is_binary(error) do
+    snapshot(source,
+      availability: :unknown,
+      state: :error,
+      attempted_at: now(),
+      error: error
+    )
+  end
+
+  defp do_refresh_source(%Source{} = source) do
+    attempted_at = now()
+
+    with {:ok, credential} <- TokenCodec.credential(source.stored_token),
+         {:ok, %Result{} = result} <- source.adapter.fetch(credential, source) do
+      snapshot(source,
+        availability: result.availability,
+        state: :fresh,
+        plan: result.plan,
+        windows: result.windows,
+        refreshed_at: attempted_at,
+        attempted_at: attempted_at
+      )
+    else
+      {:error, {:provider_token_codec, _reason}} ->
+        error_snapshot(source, attempted_at, :credential_unavailable)
+
+      {:error, reason} ->
+        error_snapshot(source, attempted_at, reason)
+    end
+  end
+
+  defp error_snapshot(source, attempted_at, reason) do
+    snapshot(source,
+      availability: :unknown,
+      state: :error,
+      attempted_at: attempted_at,
+      error: safe_error(reason)
+    )
+  end
+
+  defp snapshot(source, attrs) do
+    struct!(Snapshot, %{
+      token_id: source.token_id,
+      provider_label: source.provider_label,
+      account_label: source.account_label,
+      plan: Keyword.get(attrs, :plan),
+      availability: Keyword.fetch!(attrs, :availability),
+      state: Keyword.fetch!(attrs, :state),
+      windows: Keyword.get(attrs, :windows, []),
+      refreshed_at: Keyword.get(attrs, :refreshed_at),
+      attempted_at: Keyword.get(attrs, :attempted_at),
+      error: Keyword.get(attrs, :error)
+    })
+  end
+
+  defp safe_error(:unsupported), do: "Provider does not report usage for this account"
+  defp safe_error(:authentication_failed), do: "Provider authentication failed"
+  defp safe_error(:credential_expired), do: "Provider credential expired"
+  defp safe_error(:credential_unavailable), do: "Provider credential is unavailable"
+  defp safe_error(:token_refresh_failed), do: "Provider credential refresh failed"
+  defp safe_error(:rate_limited), do: "Provider usage API is rate limited"
+  defp safe_error(:timeout), do: "Provider usage API timed out"
+  defp safe_error(:unavailable), do: "Provider usage API is unavailable"
+  defp safe_error(:not_found), do: "Provider usage API is unsupported"
+  defp safe_error(:invalid_response), do: "Provider returned invalid usage data"
+  defp safe_error(_reason), do: "Provider usage refresh failed"
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+end

--- a/lib/llm_proxy/provider_usage/result.ex
+++ b/lib/llm_proxy/provider_usage/result.ex
@@ -1,0 +1,16 @@
+defmodule LLMProxy.ProviderUsage.Result do
+  @moduledoc "Normalized provider result without credential data."
+
+  alias LLMProxy.ProviderUsage.Window
+
+  @enforce_keys [:availability, :windows]
+  defstruct [:plan, :expires_at, availability: :unknown, windows: []]
+
+  @type availability :: :available | :limited | :unavailable | :unknown
+  @type t :: %__MODULE__{
+          availability: availability(),
+          windows: [Window.t()],
+          plan: String.t() | nil,
+          expires_at: DateTime.t() | nil
+        }
+end

--- a/lib/llm_proxy/provider_usage/server.ex
+++ b/lib/llm_proxy/provider_usage/server.ex
@@ -1,0 +1,271 @@
+defmodule LLMProxy.ProviderUsage.Server do
+  @moduledoc """
+  Supervised cache and bounded refresh scheduler for provider usage.
+
+  One task refreshes accounts sequentially. A second manual or automatic
+  request cannot start another task while that refresh is active.
+  """
+
+  use GenServer
+
+  alias LLMProxy.ProviderUsage.{Loader, Snapshot}
+
+  defmodule State do
+    @moduledoc false
+    defstruct [
+      :task,
+      :scope,
+      :timer,
+      :task_supervisor,
+      :refresh_fun,
+      snapshots: %{},
+      auto_refresh: true,
+      refresh_interval_ms: 300_000,
+      stale_after_ms: 600_000
+    ]
+  end
+
+  @type scope :: :all | {:account, integer()}
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec snapshots(GenServer.server()) :: [Snapshot.t()]
+  def snapshots(server \\ __MODULE__) do
+    snapshots_at(server, DateTime.utc_now())
+  end
+
+  @doc false
+  @spec snapshots_at(GenServer.server(), DateTime.t()) :: [Snapshot.t()]
+  def snapshots_at(server, %DateTime{} = at) do
+    GenServer.call(server, {:snapshots, at})
+  end
+
+  @spec refresh_all(GenServer.server()) :: {:ok, :started | :already_refreshing}
+  def refresh_all(server \\ __MODULE__), do: GenServer.call(server, {:refresh, :all})
+
+  @spec refresh_account(integer(), GenServer.server()) :: {:ok, :started | :already_refreshing}
+  def refresh_account(id, server \\ __MODULE__) when is_integer(id) do
+    GenServer.call(server, {:refresh, {:account, id}})
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    auto_refresh =
+      Keyword.get(opts, :auto_refresh, LLMProxy.Config.provider_usage_auto_refresh?())
+
+    state = %State{
+      auto_refresh: auto_refresh,
+      refresh_interval_ms:
+        Keyword.get(
+          opts,
+          :refresh_interval_ms,
+          LLMProxy.Config.provider_usage_refresh_interval_ms()
+        ),
+      stale_after_ms:
+        Keyword.get(opts, :stale_after_ms, LLMProxy.Config.provider_usage_stale_after_ms()),
+      task_supervisor: Keyword.get(opts, :task_supervisor, LLMProxy.ProviderUsage.TaskSupervisor),
+      refresh_fun: Keyword.get(opts, :refresh_fun, &Loader.refresh/1)
+    }
+
+    {:ok, schedule_initial(state)}
+  end
+
+  @impl true
+  def handle_call({:snapshots, at}, _from, state) do
+    snapshots =
+      state.snapshots
+      |> Enum.map(fn {_token_id, snapshot} ->
+        stale_snapshot(snapshot, at, state.stale_after_ms)
+      end)
+      |> Enum.sort_by(& &1.token_id)
+
+    {:reply, snapshots, state}
+  end
+
+  def handle_call({:refresh, scope}, _from, %State{task: nil} = state) do
+    {:reply, {:ok, :started}, start_refresh(state, scope)}
+  end
+
+  def handle_call({:refresh, _scope}, _from, state) do
+    {:reply, {:ok, :already_refreshing}, state}
+  end
+
+  @impl true
+  def handle_info(:auto_refresh, %State{task: nil} = state) do
+    {:noreply, start_refresh(%{state | timer: nil}, :all)}
+  end
+
+  def handle_info(:auto_refresh, state), do: {:noreply, %{state | timer: nil}}
+
+  def handle_info({ref, snapshots}, %State{task: %Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+
+    state =
+      state
+      |> apply_refresh(snapshots)
+      |> finish_refresh()
+
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{task: %Task{ref: ref}} = state) do
+    state =
+      state
+      |> fail_refresh()
+      |> finish_refresh()
+
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    cancel_timer(state.timer)
+    cancel_task(state)
+    :ok
+  end
+
+  defp start_refresh(state, scope) do
+    cancel_timer(state.timer)
+
+    task =
+      Task.Supervisor.async_nolink(state.task_supervisor, fn ->
+        state.refresh_fun.(scope)
+      end)
+
+    Process.link(task.pid)
+
+    %{
+      state
+      | task: task,
+        scope: scope,
+        timer: nil,
+        snapshots: mark_refreshing(state.snapshots, scope)
+    }
+  end
+
+  defp apply_refresh(state, snapshots) when is_list(snapshots) do
+    snapshots = Enum.filter(snapshots, &match?(%Snapshot{}, &1))
+
+    refreshed =
+      case state.scope do
+        :all ->
+          Map.new(snapshots, fn snapshot ->
+            {snapshot.token_id, merge_snapshot(state.snapshots[snapshot.token_id], snapshot)}
+          end)
+
+        {:account, id} ->
+          state.snapshots
+          |> Map.delete(id)
+          |> Map.merge(
+            Map.new(snapshots, fn snapshot ->
+              {snapshot.token_id, merge_snapshot(state.snapshots[snapshot.token_id], snapshot)}
+            end)
+          )
+      end
+
+    %{state | snapshots: refreshed}
+  end
+
+  defp apply_refresh(state, _invalid_result), do: fail_refresh(state)
+
+  defp merge_snapshot(
+         %Snapshot{refreshed_at: %DateTime{}} = previous,
+         %Snapshot{state: :error} = failed
+       ) do
+    %{
+      failed
+      | availability: previous.availability,
+        state: :stale,
+        plan: previous.plan,
+        windows: previous.windows,
+        refreshed_at: previous.refreshed_at
+    }
+  end
+
+  defp merge_snapshot(_previous, snapshot), do: snapshot
+
+  defp fail_refresh(state) do
+    snapshots =
+      Map.new(state.snapshots, fn {id, snapshot} ->
+        if selected?(id, state.scope) do
+          failed = %{
+            snapshot
+            | state: if(snapshot.refreshed_at, do: :stale, else: :error),
+              error: "Provider usage refresh failed",
+              attempted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+          }
+
+          {id, failed}
+        else
+          {id, snapshot}
+        end
+      end)
+
+    %{state | snapshots: snapshots}
+  end
+
+  defp finish_refresh(state) do
+    state
+    |> Map.put(:task, nil)
+    |> Map.put(:scope, nil)
+    |> schedule_next()
+  end
+
+  defp mark_refreshing(snapshots, scope) do
+    Map.new(snapshots, fn {id, snapshot} ->
+      if selected?(id, scope) do
+        {id, %{snapshot | state: :refreshing, error: nil}}
+      else
+        {id, snapshot}
+      end
+    end)
+  end
+
+  defp selected?(_id, :all), do: true
+  defp selected?(id, {:account, id}), do: true
+  defp selected?(_id, _scope), do: false
+
+  defp stale_snapshot(
+         %Snapshot{state: :fresh, refreshed_at: refreshed_at} = snapshot,
+         at,
+         max_age
+       )
+       when not is_nil(refreshed_at) do
+    if DateTime.diff(at, refreshed_at, :millisecond) > max_age do
+      %{snapshot | state: :stale, error: snapshot.error || "Provider usage data is stale"}
+    else
+      snapshot
+    end
+  end
+
+  defp stale_snapshot(snapshot, _at, _max_age), do: snapshot
+
+  defp schedule_initial(%State{auto_refresh: true} = state) do
+    %{state | timer: Process.send_after(self(), :auto_refresh, 1_000)}
+  end
+
+  defp schedule_initial(state), do: state
+
+  defp schedule_next(%State{auto_refresh: true} = state) do
+    %{state | timer: Process.send_after(self(), :auto_refresh, state.refresh_interval_ms)}
+  end
+
+  defp schedule_next(state), do: state
+
+  defp cancel_timer(nil), do: :ok
+  defp cancel_timer(timer), do: Process.cancel_timer(timer, async: false, info: false)
+
+  defp cancel_task(%State{task: nil}), do: :ok
+
+  defp cancel_task(%State{task: task, task_supervisor: supervisor}) do
+    _result = Task.Supervisor.terminate_child(supervisor, task.pid)
+    :ok
+  end
+end

--- a/lib/llm_proxy/provider_usage/server.ex
+++ b/lib/llm_proxy/provider_usage/server.ex
@@ -8,7 +8,7 @@ defmodule LLMProxy.ProviderUsage.Server do
 
   use GenServer
 
-  alias LLMProxy.ProviderUsage.{Loader, Snapshot}
+  alias LLMProxy.ProviderUsage.{Loader, Snapshot, Window}
 
   defmodule State do
     @moduledoc false
@@ -47,7 +47,7 @@ defmodule LLMProxy.ProviderUsage.Server do
   def refresh_all(server \\ __MODULE__), do: GenServer.call(server, {:refresh, :all})
 
   @spec refresh_account(integer(), GenServer.server()) :: {:ok, :started | :already_refreshing}
-  def refresh_account(id, server \\ __MODULE__) when is_integer(id) do
+  def refresh_account(id, server \\ __MODULE__) when is_integer(id) and id > 0 do
     GenServer.call(server, {:refresh, {:account, id}})
   end
 
@@ -150,30 +150,100 @@ defmodule LLMProxy.ProviderUsage.Server do
     }
   end
 
-  defp apply_refresh(state, snapshots) when is_list(snapshots) do
-    snapshots = Enum.filter(snapshots, &match?(%Snapshot{}, &1))
-
-    refreshed =
-      case state.scope do
-        :all ->
-          Map.new(snapshots, fn snapshot ->
-            {snapshot.token_id, merge_snapshot(state.snapshots[snapshot.token_id], snapshot)}
-          end)
-
-        {:account, id} ->
-          state.snapshots
-          |> Map.delete(id)
-          |> Map.merge(
-            Map.new(snapshots, fn snapshot ->
-              {snapshot.token_id, merge_snapshot(state.snapshots[snapshot.token_id], snapshot)}
-            end)
-          )
-      end
-
-    %{state | snapshots: refreshed}
+  defp apply_refresh(state, snapshots) do
+    if valid_refresh_result?(snapshots, state.scope) do
+      %{state | snapshots: refreshed_snapshots(state, snapshots)}
+    else
+      fail_refresh(state)
+    end
   end
 
-  defp apply_refresh(state, _invalid_result), do: fail_refresh(state)
+  defp refreshed_snapshots(state, snapshots) do
+    refreshed =
+      Map.new(snapshots, fn snapshot ->
+        {snapshot.token_id, merge_snapshot(state.snapshots[snapshot.token_id], snapshot)}
+      end)
+
+    case state.scope do
+      :all -> refreshed
+      {:account, id} -> state.snapshots |> Map.delete(id) |> Map.merge(refreshed)
+    end
+  end
+
+  defp valid_refresh_result?(snapshots, scope) when is_list(snapshots) do
+    ids = Enum.map(snapshots, &snapshot_id/1)
+
+    Enum.all?(snapshots, &valid_snapshot?/1) and
+      Enum.all?(ids, &scope_allows_id?(scope, &1)) and
+      length(ids) == MapSet.size(MapSet.new(ids))
+  end
+
+  defp valid_refresh_result?(_snapshots, _scope), do: false
+
+  defp snapshot_id(%Snapshot{token_id: id}), do: id
+  defp snapshot_id(_snapshot), do: nil
+
+  defp scope_allows_id?(:all, id), do: is_integer(id) and id > 0
+  defp scope_allows_id?({:account, id}, id), do: true
+  defp scope_allows_id?(_scope, _id), do: false
+
+  defp valid_snapshot?(%Snapshot{} = snapshot) do
+    valid_snapshot_identity?(snapshot) and valid_snapshot_state?(snapshot) and
+      valid_plan?(snapshot.plan) and valid_datetime?(snapshot.refreshed_at) and
+      valid_datetime?(snapshot.attempted_at) and valid_error?(snapshot.error) and
+      is_list(snapshot.windows) and length(snapshot.windows) <= 8 and
+      Enum.all?(snapshot.windows, &valid_window?/1)
+  end
+
+  defp valid_snapshot?(_snapshot), do: false
+
+  defp valid_snapshot_identity?(snapshot) do
+    is_integer(snapshot.token_id) and snapshot.token_id > 0 and
+      valid_label?(snapshot.provider_label, 80) and valid_label?(snapshot.account_label, 80)
+  end
+
+  defp valid_snapshot_state?(%Snapshot{state: :fresh} = snapshot) do
+    snapshot.availability in [:available, :limited, :unavailable] and
+      match?(%DateTime{}, snapshot.refreshed_at) and
+      match?(%DateTime{}, snapshot.attempted_at) and is_nil(snapshot.error)
+  end
+
+  defp valid_snapshot_state?(%Snapshot{state: :error} = snapshot) do
+    snapshot.availability == :unknown and is_nil(snapshot.refreshed_at) and
+      match?(%DateTime{}, snapshot.attempted_at) and is_binary(snapshot.error)
+  end
+
+  defp valid_snapshot_state?(%Snapshot{state: :disabled} = snapshot) do
+    snapshot.availability == :unavailable and snapshot.windows == [] and
+      is_nil(snapshot.refreshed_at)
+  end
+
+  defp valid_snapshot_state?(_snapshot), do: false
+
+  defp valid_window?(%Window{} = window) do
+    valid_label?(window.label, 40) and valid_percent?(window.used_percent) and
+      valid_percent?(window.remaining_percent) and
+      abs(window.used_percent + window.remaining_percent - 100) < 0.11 and
+      valid_datetime?(window.resets_at) and
+      (is_nil(window.duration_seconds) or
+         (is_integer(window.duration_seconds) and window.duration_seconds > 0))
+  end
+
+  defp valid_window?(_window), do: false
+
+  defp valid_percent?(value), do: is_number(value) and value >= 0 and value <= 100
+  defp valid_datetime?(nil), do: true
+  defp valid_datetime?(%DateTime{}), do: true
+  defp valid_datetime?(_value), do: false
+  defp valid_plan?(nil), do: true
+  defp valid_plan?(plan), do: valid_label?(plan, 40)
+  defp valid_error?(nil), do: true
+  defp valid_error?(error), do: valid_label?(error, 160)
+
+  defp valid_label?(value, maximum) do
+    is_binary(value) and value != "" and byte_size(value) <= maximum and
+      not String.contains?(value, ["\r", "\n"])
+  end
 
   defp merge_snapshot(
          %Snapshot{refreshed_at: %DateTime{}} = previous,

--- a/lib/llm_proxy/provider_usage/snapshot.ex
+++ b/lib/llm_proxy/provider_usage/snapshot.ex
@@ -1,0 +1,33 @@
+defmodule LLMProxy.ProviderUsage.Snapshot do
+  @moduledoc "Cached, redacted usage state for one provider-token record."
+
+  alias LLMProxy.ProviderUsage.{Result, Window}
+
+  @enforce_keys [:token_id, :provider_label, :account_label, :availability, :state]
+  defstruct [
+    :token_id,
+    :provider_label,
+    :account_label,
+    :plan,
+    :availability,
+    :state,
+    :refreshed_at,
+    :attempted_at,
+    :error,
+    windows: []
+  ]
+
+  @type state :: :fresh | :refreshing | :stale | :error | :disabled
+  @type t :: %__MODULE__{
+          token_id: integer(),
+          provider_label: String.t(),
+          account_label: String.t(),
+          plan: String.t() | nil,
+          availability: Result.availability(),
+          state: state(),
+          windows: [Window.t()],
+          refreshed_at: DateTime.t() | nil,
+          attempted_at: DateTime.t() | nil,
+          error: String.t() | nil
+        }
+end

--- a/lib/llm_proxy/provider_usage/source.ex
+++ b/lib/llm_proxy/provider_usage/source.ex
@@ -76,7 +76,7 @@ defmodule LLMProxy.ProviderUsage.Source do
         account_label: account_label(token),
         base_url: base_url,
         usage_paths: [codex_usage_path(base_url)],
-        config_error: codex_source_error(base_url)
+        config_error: endpoint_or_source_error(token, codex_source_error(base_url))
       }
     ]
   end
@@ -123,28 +123,18 @@ defmodule LLMProxy.ProviderUsage.Source do
   end
 
   defp glm_provider?(config) do
-    usage_adapter = normalize_name(Map.get(config, :usage_adapter))
+    usage_adapter = Map.get(config, :usage_adapter)
     adapter = normalize_name(Map.get(config, :adapter))
 
     usage_adapter == "glm" or adapter in @glm_adapters
   end
 
-  defp usage_paths(config) do
-    paths =
-      case Map.get(config, :usage_paths) do
-        paths when is_list(paths) -> Enum.map(paths, &path_value/1)
-        path when is_binary(path) -> [path]
-        _other -> @default_glm_paths
-      end
-
-    Enum.uniq(paths)
-  end
+  defp usage_paths(config), do: Map.get(config, :usage_paths, @default_glm_paths)
 
   defp auth_scheme(config) do
-    case normalize_name(Map.get(config, :usage_auth_scheme, "raw")) do
+    case Map.get(config, :usage_auth_scheme, "raw") do
       "raw" -> :raw
       "bearer" -> :bearer
-      _other -> nil
     end
   end
 
@@ -213,12 +203,28 @@ defmodule LLMProxy.ProviderUsage.Source do
   defp valid_path?(_path), do: false
 
   defp account_attrs(%ProviderToken{} = token) do
-    %{
+    attrs = %{
       token_id: token.id,
       stored_token: token,
       account_label: account_label(token)
     }
+
+    case endpoint_override_error(token) do
+      nil -> attrs
+      error -> Map.put(attrs, :config_error, error)
+    end
   end
+
+  defp endpoint_or_source_error(token, source_error) do
+    endpoint_override_error(token) || source_error
+  end
+
+  defp endpoint_override_error(%ProviderToken{proxy: proxy})
+       when is_binary(proxy) and proxy != "" do
+    "Provider usage is unavailable for tokens with endpoint overrides"
+  end
+
+  defp endpoint_override_error(%ProviderToken{}), do: nil
 
   defp account_label(%ProviderToken{id: id, label: label}) do
     case safe_label(label) do
@@ -254,9 +260,6 @@ defmodule LLMProxy.ProviderUsage.Source do
     |> String.downcase()
     |> String.replace("-", "_")
   end
-
-  defp path_value(value) when is_binary(value), do: value
-  defp path_value(_value), do: nil
 
   defp pool_name(value) when is_binary(value), do: value
   defp pool_name(value) when is_atom(value), do: Atom.to_string(value)

--- a/lib/llm_proxy/provider_usage/source.ex
+++ b/lib/llm_proxy/provider_usage/source.ex
@@ -1,0 +1,264 @@
+defmodule LLMProxy.ProviderUsage.Source do
+  @moduledoc """
+  Resolves provider-token records to qualified live usage sources.
+
+  Codex is a built-in source. GLM sources come from named providers that use a
+  Z.AI adapter or explicitly set `usage_adapter: "glm"`.
+  """
+
+  alias LLMProxy.ProviderUsage.Adapters.{Codex, GLM}
+  alias LLMProxy.Schemas.ProviderToken
+
+  @glm_adapters ~w(zai zai_coder zai_coding_plan)
+  @default_glm_paths ["/api/monitor/usage/quota/limit", "/api/monitor/usage"]
+
+  @derive {Inspect, except: [:stored_token]}
+  @enforce_keys [
+    :token_id,
+    :stored_token,
+    :adapter,
+    :provider_label,
+    :account_label,
+    :usage_paths
+  ]
+  defstruct [
+    :token_id,
+    :stored_token,
+    :adapter,
+    :provider_label,
+    :account_label,
+    :base_url,
+    :auth_scheme,
+    :config_error,
+    usage_paths: []
+  ]
+
+  @type t :: %__MODULE__{
+          token_id: integer(),
+          stored_token: ProviderToken.t(),
+          adapter: module(),
+          provider_label: String.t(),
+          account_label: String.t(),
+          base_url: String.t() | nil,
+          usage_paths: [String.t()],
+          auth_scheme: :raw | :bearer | nil,
+          config_error: String.t() | nil
+        }
+
+  @spec accounts() :: [t()]
+  def accounts do
+    glm_sources = glm_sources()
+
+    LLMProxy.Storage.list_tokens()
+    |> Enum.flat_map(&source_for(&1, glm_sources))
+    |> Enum.sort_by(& &1.token_id)
+  end
+
+  @spec supported_account?(integer()) :: boolean()
+  def supported_account?(id) when is_integer(id) do
+    Enum.any?(accounts(), &(&1.token_id == id))
+  end
+
+  def supported_account?(_id), do: false
+
+  defp source_for(%ProviderToken{provider: "openai-codex", kind: "oauth"} = token, _glm) do
+    base_url =
+      "openai-codex"
+      |> LLMProxy.Config.provider_value(:base_url)
+      |> normalize_codex_base_url()
+
+    [
+      %__MODULE__{
+        token_id: token.id,
+        stored_token: token,
+        adapter: Codex,
+        provider_label: "OpenAI Codex",
+        account_label: account_label(token),
+        base_url: base_url,
+        usage_paths: [codex_usage_path(base_url)],
+        config_error: codex_source_error(base_url)
+      }
+    ]
+  end
+
+  defp source_for(%ProviderToken{provider: pool, kind: "api-key"} = token, glm_sources) do
+    case Map.get(glm_sources, pool) do
+      nil -> []
+      attrs -> [struct!(__MODULE__, Map.merge(attrs, account_attrs(token)))]
+    end
+  end
+
+  defp source_for(_token, _glm_sources), do: []
+
+  defp glm_sources do
+    LLMProxy.Config.configured_providers()
+    |> Enum.filter(fn {_name, config} -> glm_provider?(config) end)
+    |> Enum.map(fn {name, config} -> {pool_name(Map.get(config, :token_pool, name)), config} end)
+    |> Enum.reject(fn {pool, _config} -> is_nil(pool) end)
+    |> Enum.group_by(fn {pool, _config} -> pool end)
+    |> Map.new(fn {pool, providers} ->
+      provider_configs = Enum.map(providers, fn {_pool, config} -> {pool, config} end)
+      {pool, glm_source(provider_configs)}
+    end)
+  end
+
+  defp glm_source(providers) do
+    candidates =
+      providers
+      |> Enum.map(fn {_name, config} ->
+        %{
+          adapter: GLM,
+          provider_label: "GLM Coding Plan",
+          base_url: Map.get(config, :base_url),
+          usage_paths: usage_paths(config),
+          auth_scheme: auth_scheme(config)
+        }
+      end)
+      |> Enum.uniq()
+
+    case candidates do
+      [candidate] -> Map.put(candidate, :config_error, source_error(candidate))
+      [candidate | _rest] -> Map.put(candidate, :config_error, "Conflicting GLM usage sources")
+    end
+  end
+
+  defp glm_provider?(config) do
+    usage_adapter = normalize_name(Map.get(config, :usage_adapter))
+    adapter = normalize_name(Map.get(config, :adapter))
+
+    usage_adapter == "glm" or adapter in @glm_adapters
+  end
+
+  defp usage_paths(config) do
+    paths =
+      case Map.get(config, :usage_paths) do
+        paths when is_list(paths) -> Enum.map(paths, &path_value/1)
+        path when is_binary(path) -> [path]
+        _other -> @default_glm_paths
+      end
+
+    Enum.uniq(paths)
+  end
+
+  defp auth_scheme(config) do
+    case normalize_name(Map.get(config, :usage_auth_scheme, "raw")) do
+      "raw" -> :raw
+      "bearer" -> :bearer
+      _other -> nil
+    end
+  end
+
+  defp source_error(%{base_url: base_url, usage_paths: paths, auth_scheme: auth_scheme}) do
+    cond do
+      not valid_base_url?(base_url) ->
+        "GLM usage base URL is not a valid HTTPS URL"
+
+      paths == [] or length(paths) > 3 or not Enum.all?(paths, &valid_path?/1) ->
+        "GLM usage path is invalid"
+
+      is_nil(auth_scheme) ->
+        "GLM usage authorization scheme is invalid"
+
+      true ->
+        nil
+    end
+  end
+
+  defp codex_source_error(base_url) do
+    if valid_base_url?(base_url),
+      do: nil,
+      else: "Codex usage base URL is not a valid HTTPS URL"
+  end
+
+  defp codex_usage_path(base_url) when is_binary(base_url) do
+    base_path = URI.parse(base_url).path || ""
+
+    suffix =
+      if String.contains?(base_path, "/backend-api"), do: "/wham/usage", else: "/api/codex/usage"
+
+    String.trim_trailing(base_path, "/") <> suffix
+  end
+
+  defp codex_usage_path(_base_url), do: "/api/codex/usage"
+
+  defp normalize_codex_base_url(base_url) when is_binary(base_url) do
+    uri = URI.parse(base_url)
+    path = String.trim_trailing(uri.path || "", "/")
+
+    if uri.host in ["chatgpt.com", "chat.openai.com"] and
+         not String.contains?(path, "/backend-api") do
+      %{uri | path: path <> "/backend-api"} |> URI.to_string()
+    else
+      %{uri | path: path} |> URI.to_string()
+    end
+  end
+
+  defp normalize_codex_base_url(base_url), do: base_url
+
+  defp valid_base_url?(base_url) when is_binary(base_url) do
+    match?(
+      %URI{scheme: "https", host: host, userinfo: nil} when is_binary(host) and host != "",
+      URI.parse(base_url)
+    )
+  end
+
+  defp valid_base_url?(_base_url), do: false
+
+  defp valid_path?(path) when is_binary(path) do
+    byte_size(path) <= 256 and String.starts_with?(path, "/") and
+      not String.starts_with?(path, "//") and
+      not String.contains?(path, ["?", "#", "\\", "\r", "\n"])
+  end
+
+  defp valid_path?(_path), do: false
+
+  defp account_attrs(%ProviderToken{} = token) do
+    %{
+      token_id: token.id,
+      stored_token: token,
+      account_label: account_label(token)
+    }
+  end
+
+  defp account_label(%ProviderToken{id: id, label: label}) do
+    case safe_label(label) do
+      nil -> "Account ##{id}"
+      safe -> "#{redact_label(safe)} · ##{id}"
+    end
+  end
+
+  defp safe_label(label) when is_binary(label) do
+    label = String.trim(label)
+
+    if String.length(label) <= 40 and Regex.match?(~r/^[[:alnum:]][[:alnum:] _.\-]*$/u, label) do
+      label
+    else
+      nil
+    end
+  end
+
+  defp safe_label(_label), do: nil
+
+  defp redact_label(label) do
+    characters = String.graphemes(label)
+    "#{List.first(characters)}***#{List.last(characters)}"
+  end
+
+  defp normalize_name(nil), do: nil
+
+  defp normalize_name(value) when not (is_binary(value) or is_atom(value)), do: nil
+
+  defp normalize_name(value) do
+    value
+    |> to_string()
+    |> String.downcase()
+    |> String.replace("-", "_")
+  end
+
+  defp path_value(value) when is_binary(value), do: value
+  defp path_value(_value), do: nil
+
+  defp pool_name(value) when is_binary(value), do: value
+  defp pool_name(value) when is_atom(value), do: Atom.to_string(value)
+  defp pool_name(_value), do: nil
+end

--- a/lib/llm_proxy/provider_usage/window.ex
+++ b/lib/llm_proxy/provider_usage/window.ex
@@ -1,0 +1,14 @@
+defmodule LLMProxy.ProviderUsage.Window do
+  @moduledoc "One authoritative upstream usage window."
+
+  @enforce_keys [:label, :used_percent, :remaining_percent]
+  defstruct [:label, :used_percent, :remaining_percent, :resets_at, :duration_seconds]
+
+  @type t :: %__MODULE__{
+          label: String.t(),
+          used_percent: number(),
+          remaining_percent: number(),
+          resets_at: DateTime.t() | nil,
+          duration_seconds: non_neg_integer() | nil
+        }
+end

--- a/test/llm_proxy/admin/dashboards/provider_usage_test.exs
+++ b/test/llm_proxy/admin/dashboards/provider_usage_test.exs
@@ -1,0 +1,25 @@
+if Code.ensure_loaded?(Incant) do
+  defmodule LLMProxy.Admin.Dashboards.ProviderUsageTest do
+    use ExUnit.Case, async: false
+
+    @moduletag :incant
+
+    alias LLMProxy.Admin.Dashboards.ProviderUsage
+
+    test "returns the portable provider usage dashboard shape" do
+      assert is_integer(ProviderUsage.accounts(%{}, %{}))
+      assert is_integer(ProviderUsage.available(%{}, %{}))
+      assert is_integer(ProviderUsage.attention(%{}, %{}))
+
+      assert %{columns: columns, rows: rows} = ProviderUsage.usage_windows(%{}, %{})
+      assert :provider in columns
+      assert :account in columns
+      assert :used_percent in columns
+      assert :remaining_percent in columns
+      assert :resets_at in columns
+      assert :last_refresh in columns
+      assert :error in columns
+      assert is_list(rows)
+    end
+  end
+end

--- a/test/llm_proxy/admin/resources/provider_token_test.exs
+++ b/test/llm_proxy/admin/resources/provider_token_test.exs
@@ -22,6 +22,9 @@ if Code.ensure_loaded?(Incant) do
       assert {:ok, %ActionResult.Refresh{}} = ProviderToken.enable(%{id: id}, %{})
       assert [%{enabled: true}] = Storage.list_tokens(%{provider: "openai"})
 
+      assert {:error, "Usage tracking is not supported for this token"} =
+               ProviderToken.refresh_usage(%{id: id}, %{})
+
       assert {:ok, %ActionResult.Refresh{}} = ProviderToken.remove(%{id: id}, %{})
       assert Storage.list_tokens(%{provider: "openai"}) == []
     end

--- a/test/llm_proxy/admin_test.exs
+++ b/test/llm_proxy/admin_test.exs
@@ -80,7 +80,8 @@ if Code.ensure_loaded?(Incant) do
 
       assert Enum.map(provider_token.table.page_actions, & &1.id) == [
                "codex_oauth_start",
-               "codex_oauth_complete"
+               "codex_oauth_complete",
+               "refresh_all_usage"
              ]
 
       provider_filter = Enum.find(provider_token.table.filters, &(&1.id == "provider"))
@@ -97,6 +98,7 @@ if Code.ensure_loaded?(Incant) do
       provider_metadata = Incant.metadata(LLMProxy.Admin.Resources.ProviderToken)
       enable = Enum.find(provider_metadata.table.actions, &(&1.name == :enable))
       disable = Enum.find(provider_metadata.table.actions, &(&1.name == :disable))
+      refresh_usage = Enum.find(provider_metadata.table.actions, &(&1.name == :refresh_usage))
 
       assert enable.opts[:callback] == {LLMProxy.Admin.Resources.ProviderToken, :enable}
       assert enable.opts[:available_if] == [enabled: false]
@@ -104,8 +106,12 @@ if Code.ensure_loaded?(Incant) do
       assert disable.opts[:available_if] == [enabled: true]
       assert disable.opts[:confirm] == "Disable this provider token?"
       assert Enum.find(provider_metadata.table.columns, &(&1.name == :proxy)).opts[:sensitive]
+      assert refresh_usage.opts[:available_if] == [enabled: true]
 
-      assert [%{id: "operations", title: "Operations"} = dashboard] = contract.dashboards
+      assert [
+               %{id: "operations", title: "Operations"} = dashboard,
+               %{id: "provider_usage", title: "Provider Usage"} = provider_usage
+             ] = contract.dashboards
 
       assert Enum.map(dashboard.widgets, & &1.id) == [
                "api_keys",
@@ -161,6 +167,32 @@ if Code.ensure_loaded?(Incant) do
              ]
 
       assert Enum.all?(dashboard.widgets, fn widget -> not Map.has_key?(widget.opts, :query) end)
+
+      assert Enum.map(provider_usage.widgets, & &1.id) == [
+               "accounts",
+               "available",
+               "attention",
+               "usage_windows"
+             ]
+
+      usage_windows = Enum.find(provider_usage.widgets, &(&1.id == "usage_windows"))
+
+      assert Enum.map(usage_windows.opts.columns, & &1.name) == [
+               :provider,
+               :account,
+               :window,
+               :used_percent,
+               :remaining_percent,
+               :resets_at,
+               :availability,
+               :state,
+               :last_refresh,
+               :last_attempt,
+               :error
+             ]
+
+      assert usage_windows.opts.preview_rows == 50
+      assert Enum.all?(provider_usage.widgets, &(!Map.has_key?(&1.opts, :query)))
     end
   end
 end

--- a/test/llm_proxy/config/toml_test.exs
+++ b/test/llm_proxy/config/toml_test.exs
@@ -190,6 +190,28 @@ defmodule LLMProxy.Config.TOMLTest do
            }
   end
 
+  test "rejects malformed provider usage source settings" do
+    assert_raise ArgumentError, ~r/usage_adapter must be glm/, fn ->
+      TOML.decode("[providers.glm]\nusage_adapter = 123")
+    end
+
+    assert_raise ArgumentError, ~r/usage_auth_scheme must be raw or bearer/, fn ->
+      TOML.decode(~s([providers.glm]\nusage_auth_scheme = "wat"))
+    end
+
+    for paths <- [
+          "[]",
+          "[1]",
+          ~s(["relative"]),
+          ~s(["/same", "/same"]),
+          ~s(["/one", "/two", "/three", "/four"])
+        ] do
+      assert_raise ArgumentError, ~r/usage_paths must contain one through three/, fn ->
+        TOML.decode("[providers.glm]\nusage_paths = #{paths}")
+      end
+    end
+  end
+
   test "returns TOML parser errors" do
     assert {:error, {:invalid_toml, _reason}} = TOML.decode("[invalid]\na = 1 b = 2")
   end

--- a/test/llm_proxy/config/toml_test.exs
+++ b/test/llm_proxy/config/toml_test.exs
@@ -25,6 +25,12 @@ defmodule LLMProxy.Config.TOMLTest do
     [provider_tokens]
     allow_plaintext = false
 
+    [provider_usage]
+    auto_refresh = false
+    refresh_interval_ms = 120000
+    request_timeout_ms = 5000
+    stale_after_ms = 600000
+
     [telemetry]
     otlp_endpoint = "http://127.0.0.1:4318"
 
@@ -58,6 +64,10 @@ defmodule LLMProxy.Config.TOMLTest do
     assert llm_proxy[:replay_policy] == :allow_uncertain
     assert llm_proxy[:provider_connect_timeout_ms] == 15_000
     refute llm_proxy[:provider_token_allow_plaintext]
+    refute llm_proxy[:provider_usage_auto_refresh]
+    assert llm_proxy[:provider_usage_refresh_interval_ms] == 120_000
+    assert llm_proxy[:provider_usage_request_timeout_ms] == 5_000
+    assert llm_proxy[:provider_usage_stale_after_ms] == 600_000
 
     assert llm_proxy[:quackdb_server][:database] == "/var/lib/llm-proxy/main.duckdb"
     assert llm_proxy[:quackdb_server][:endpoint] == "quack:localhost:9494"
@@ -139,6 +149,39 @@ defmodule LLMProxy.Config.TOMLTest do
     assert_raise ArgumentError, ~r/otlp_endpoint must be an absolute HTTP/, fn ->
       TOML.decode(~s([telemetry]\notlp_endpoint = "localhost:4318"))
     end
+
+    assert_raise ArgumentError, ~r/refresh_interval_ms must be from 60000 through 3600000/, fn ->
+      TOML.decode("[provider_usage]\nrefresh_interval_ms = 59999")
+    end
+
+    assert_raise ArgumentError, ~r/stale_after_ms must be from 300000 through 86400000/, fn ->
+      TOML.decode("[provider_usage]\nstale_after_ms = 120000")
+    end
+  end
+
+  test "decodes explicit GLM usage source settings" do
+    input = """
+    [providers.glm]
+    adapter = "zai_coding_plan"
+    base_url = "https://api.z.ai/api/coding/paas/v4"
+    token_pool = "glm-production"
+    usage_adapter = "glm"
+    usage_auth_scheme = "bearer"
+    usage_paths = ["/api/monitor/usage"]
+    """
+
+    assert {:ok, [llm_proxy: config]} = TOML.decode(input)
+
+    assert config[:providers] == %{
+             "glm" => %{
+               adapter: "zai_coding_plan",
+               base_url: "https://api.z.ai/api/coding/paas/v4",
+               token_pool: "glm-production",
+               usage_adapter: "glm",
+               usage_auth_scheme: "bearer",
+               usage_paths: ["/api/monitor/usage"]
+             }
+           }
   end
 
   test "returns TOML parser errors" do

--- a/test/llm_proxy/config/toml_test.exs
+++ b/test/llm_proxy/config/toml_test.exs
@@ -203,6 +203,8 @@ defmodule LLMProxy.Config.TOMLTest do
           "[]",
           "[1]",
           ~s(["relative"]),
+          ~s(["/api usage"]),
+          ~S(["/api\tusage"]),
           ~s(["/same", "/same"]),
           ~s(["/one", "/two", "/three", "/four"])
         ] do

--- a/test/llm_proxy/config_test.exs
+++ b/test/llm_proxy/config_test.exs
@@ -23,6 +23,17 @@ defmodule LLMProxy.ConfigTest do
     original_provider_token_allow_plaintext =
       Application.fetch_env(:llm_proxy, :provider_token_allow_plaintext)
 
+    original_usage_auto_refresh = Application.get_env(:llm_proxy, :provider_usage_auto_refresh)
+
+    original_usage_interval =
+      Application.get_env(:llm_proxy, :provider_usage_refresh_interval_ms)
+
+    original_usage_timeout =
+      Application.get_env(:llm_proxy, :provider_usage_request_timeout_ms)
+
+    original_usage_stale_after =
+      Application.get_env(:llm_proxy, :provider_usage_stale_after_ms)
+
     on_exit(fn ->
       restore_env(:providers, original_providers)
       restore_env(:catalog, original_catalog)
@@ -40,6 +51,11 @@ defmodule LLMProxy.ConfigTest do
         :provider_token_allow_plaintext,
         original_provider_token_allow_plaintext
       )
+
+      restore_env(:provider_usage_auto_refresh, original_usage_auto_refresh)
+      restore_env(:provider_usage_refresh_interval_ms, original_usage_interval)
+      restore_env(:provider_usage_request_timeout_ms, original_usage_timeout)
+      restore_env(:provider_usage_stale_after_ms, original_usage_stale_after)
     end)
 
     :ok
@@ -123,6 +139,31 @@ defmodule LLMProxy.ConfigTest do
 
     assert {:error, :invalid_codec_options} =
              TokenCodec.validate_configuration()
+  end
+
+  test "bounds provider usage refresh work" do
+    Application.put_env(:llm_proxy, :provider_usage_auto_refresh, true)
+    Application.put_env(:llm_proxy, :provider_usage_refresh_interval_ms, 60_000)
+    Application.put_env(:llm_proxy, :provider_usage_request_timeout_ms, 1_000)
+    Application.put_env(:llm_proxy, :provider_usage_stale_after_ms, 120_000)
+
+    assert Config.provider_usage_auto_refresh?()
+    assert Config.provider_usage_refresh_interval_ms() == 60_000
+    assert Config.provider_usage_request_timeout_ms() == 1_000
+    assert Config.provider_usage_stale_after_ms() == 120_000
+
+    Application.put_env(:llm_proxy, :provider_usage_refresh_interval_ms, 59_999)
+
+    assert_raise ArgumentError, ~r/provider_usage_refresh_interval_ms/, fn ->
+      Config.provider_usage_refresh_interval_ms()
+    end
+
+    Application.put_env(:llm_proxy, :provider_usage_refresh_interval_ms, 60_000)
+    Application.put_env(:llm_proxy, :provider_usage_request_timeout_ms, 30_001)
+
+    assert_raise ArgumentError, ~r/provider_usage_request_timeout_ms/, fn ->
+      Config.provider_usage_request_timeout_ms()
+    end
   end
 
   test "configures bounded concurrent ReqLLM streaming pools" do

--- a/test/llm_proxy/config_test.exs
+++ b/test/llm_proxy/config_test.exs
@@ -106,6 +106,9 @@ defmodule LLMProxy.ConfigTest do
           %{"glm" => %{usage_paths: "/api/monitor/usage"}},
           %{"glm" => %{usage_paths: []}},
           %{"glm" => %{usage_paths: ["relative"]}},
+          %{"glm" => %{usage_paths: ["/api usage"]}},
+          %{"glm" => %{usage_paths: ["/api\tusage"]}},
+          %{"glm" => %{usage_paths: [<<"/api/", 0xFF>>]}},
           %{"glm" => %{usage_paths: ["/same", "/same"]}}
         ] do
       Application.put_env(:llm_proxy, :providers, invalid)

--- a/test/llm_proxy/config_test.exs
+++ b/test/llm_proxy/config_test.exs
@@ -87,6 +87,32 @@ defmodule LLMProxy.ConfigTest do
     end
   end
 
+  test "validates exact provider usage configuration in library mode" do
+    valid = %{
+      "glm" => %{
+        adapter: :zai_coding_plan,
+        usage_adapter: "glm",
+        usage_auth_scheme: "bearer",
+        usage_paths: ["/api/monitor/usage"]
+      }
+    }
+
+    Application.put_env(:llm_proxy, :providers, valid)
+    assert Config.configured_providers() == valid
+
+    for invalid <- [
+          %{"glm" => %{usage_adapter: :glm}},
+          %{"glm" => %{usage_auth_scheme: :bearer}},
+          %{"glm" => %{usage_paths: "/api/monitor/usage"}},
+          %{"glm" => %{usage_paths: []}},
+          %{"glm" => %{usage_paths: ["relative"]}},
+          %{"glm" => %{usage_paths: ["/same", "/same"]}}
+        ] do
+      Application.put_env(:llm_proxy, :providers, invalid)
+      assert_raise ArgumentError, fn -> Config.configured_providers() end
+    end
+  end
+
   test "configures the authenticated JSON body limit in bytes" do
     Application.put_env(:llm_proxy, :body_limit_bytes, 64_000_000)
     assert Config.body_limit_bytes() == 64_000_000

--- a/test/llm_proxy/provider_usage/adapters/codex_test.exs
+++ b/test/llm_proxy/provider_usage/adapters/codex_test.exs
@@ -119,6 +119,17 @@ defmodule LLMProxy.ProviderUsage.Adapters.CodexTest do
              |> Jason.encode!()
              |> Codex.parse()
 
+    for invalid_reset <- ["not-a-timestamp", 1.5] do
+      assert {:error, {:invalid_response, _reason}} =
+               %{
+                 "rateLimits" => %{
+                   "primary" => %{"usedPercent" => 10, "resetsAt" => invalid_reset}
+                 }
+               }
+               |> Jason.encode!()
+               |> Codex.parse()
+    end
+
     assert {:error, {:invalid_response, :ambiguous_shape}} =
              %{"rate_limit" => %{}, "rateLimits" => %{}}
              |> Jason.encode!()

--- a/test/llm_proxy/provider_usage/adapters/codex_test.exs
+++ b/test/llm_proxy/provider_usage/adapters/codex_test.exs
@@ -1,0 +1,86 @@
+defmodule LLMProxy.ProviderUsage.Adapters.CodexTest do
+  use ExUnit.Case, async: true
+
+  alias LLMProxy.ProviderUsage.Adapters.Codex
+
+  test "parses primary and secondary Codex windows" do
+    primary_reset = 1_800_000_000
+    secondary_reset = 1_800_600_000
+
+    assert {:ok, result} =
+             Codex.parse(%{
+               "plan_type" => "pro",
+               "rate_limit" => %{
+                 "allowed" => true,
+                 "limit_reached" => false,
+                 "primary_window" => %{
+                   "used_percent" => 42,
+                   "limit_window_seconds" => 18_000,
+                   "reset_at" => primary_reset
+                 },
+                 "secondary_window" => %{
+                   "used_percent" => 91.25,
+                   "limit_window_seconds" => 604_800,
+                   "reset_at" => secondary_reset
+                 }
+               }
+             })
+
+    assert result.plan == "pro"
+    assert result.availability == :limited
+
+    assert [primary, secondary] = result.windows
+    assert primary.label == "5 hour"
+    assert primary.used_percent == 42
+    assert primary.remaining_percent == 58
+    assert primary.resets_at == DateTime.from_unix!(primary_reset)
+
+    assert secondary.label == "Weekly"
+    assert secondary.used_percent == 91.3
+    assert secondary.remaining_percent == 8.7
+    assert secondary.resets_at == DateTime.from_unix!(secondary_reset)
+  end
+
+  test "honors provider availability and alternate app-server field names" do
+    assert {:ok, result} =
+             Codex.parse(%{
+               "rate_limits" => %{
+                 "allowed" => false,
+                 "primary" => %{
+                   "usedPercent" => 20,
+                   "windowDurationMins" => 15,
+                   "resetsAt" => "1800000000"
+                 }
+               }
+             })
+
+    assert result.availability == :unavailable
+    assert [%{label: "15 minutes", used_percent: 20}] = result.windows
+  end
+
+  test "honors current top-level provider limit state" do
+    assert {:ok, result} =
+             Codex.parse(%{
+               "rate_limit_reached_type" => %{"type" => "rate_limit_reached"},
+               "rate_limit" => %{
+                 "primary_window" => %{
+                   "used_percent" => 20,
+                   "limit_window_seconds" => 18_000
+                 }
+               }
+             })
+
+    assert result.availability == :unavailable
+  end
+
+  test "rejects missing and malformed usage data" do
+    assert {:error, :unsupported} = Codex.parse(%{"plan_type" => "pro"})
+
+    assert {:error, :invalid_response} =
+             Codex.parse(%{
+               "rate_limit" => %{
+                 "primary_window" => %{"used_percent" => 101}
+               }
+             })
+  end
+end

--- a/test/llm_proxy/provider_usage/adapters/codex_test.exs
+++ b/test/llm_proxy/provider_usage/adapters/codex_test.exs
@@ -7,25 +7,25 @@ defmodule LLMProxy.ProviderUsage.Adapters.CodexTest do
     primary_reset = 1_800_000_000
     secondary_reset = 1_800_600_000
 
-    assert {:ok, result} =
-             Codex.parse(%{
-               "plan_type" => "pro",
-               "rate_limit" => %{
-                 "allowed" => true,
-                 "limit_reached" => false,
-                 "primary_window" => %{
-                   "used_percent" => 42,
-                   "limit_window_seconds" => 18_000,
-                   "reset_at" => primary_reset
-                 },
-                 "secondary_window" => %{
-                   "used_percent" => 91.25,
-                   "limit_window_seconds" => 604_800,
-                   "reset_at" => secondary_reset
-                 }
-               }
-             })
+    body = %{
+      "plan_type" => "pro",
+      "rate_limit" => %{
+        "allowed" => true,
+        "limit_reached" => false,
+        "primary_window" => %{
+          "used_percent" => 42,
+          "limit_window_seconds" => 18_000,
+          "reset_at" => primary_reset
+        },
+        "secondary_window" => %{
+          "used_percent" => 91.25,
+          "limit_window_seconds" => 604_800,
+          "reset_at" => secondary_reset
+        }
+      }
+    }
 
+    assert {:ok, result} = body |> Jason.encode!() |> Codex.parse()
     assert result.plan == "pro"
     assert result.availability == :limited
 
@@ -41,46 +41,91 @@ defmodule LLMProxy.ProviderUsage.Adapters.CodexTest do
     assert secondary.resets_at == DateTime.from_unix!(secondary_reset)
   end
 
-  test "honors provider availability and alternate app-server field names" do
-    assert {:ok, result} =
-             Codex.parse(%{
-               "rate_limits" => %{
-                 "allowed" => false,
-                 "primary" => %{
-                   "usedPercent" => 20,
-                   "windowDurationMins" => 15,
-                   "resetsAt" => "1800000000"
-                 }
-               }
-             })
+  test "parses the explicit legacy app-server shape" do
+    body = %{
+      "rateLimits" => %{
+        "allowed" => false,
+        "primary" => %{
+          "usedPercent" => 20,
+          "windowDurationMins" => 15,
+          "resetsAt" => "1800000000"
+        }
+      }
+    }
 
+    assert {:ok, result} = body |> Jason.encode!() |> Codex.parse()
     assert result.availability == :unavailable
     assert [%{label: "15 minutes", used_percent: 20}] = result.windows
   end
 
-  test "honors current top-level provider limit state" do
-    assert {:ok, result} =
-             Codex.parse(%{
-               "rate_limit_reached_type" => %{"type" => "rate_limit_reached"},
-               "rate_limit" => %{
-                 "primary_window" => %{
-                   "used_percent" => 20,
-                   "limit_window_seconds" => 18_000
-                 }
-               }
-             })
+  test "honors the exact current top-level provider limit state" do
+    body = %{
+      "rate_limit_reached_type" => %{"type" => "rate_limit_reached"},
+      "rate_limit" => %{
+        "primary_window" => %{
+          "used_percent" => 20,
+          "limit_window_seconds" => 18_000
+        }
+      }
+    }
 
+    assert {:ok, result} = body |> Jason.encode!() |> Codex.parse()
     assert result.availability == :unavailable
   end
 
-  test "rejects missing and malformed usage data" do
-    assert {:error, :unsupported} = Codex.parse(%{"plan_type" => "pro"})
+  test "rejects missing, malformed, ambiguous, and unknown usage data" do
+    assert {:error, {:invalid_response, _reason}} =
+             %{"plan_type" => "pro"} |> Jason.encode!() |> Codex.parse()
 
-    assert {:error, :invalid_response} =
-             Codex.parse(%{
+    assert {:error, :invalid_percent} =
+             %{
                "rate_limit" => %{
                  "primary_window" => %{"used_percent" => 101}
                }
-             })
+             }
+             |> Jason.encode!()
+             |> Codex.parse()
+
+    assert {:error, :ambiguous_duration} =
+             %{
+               "rate_limit" => %{
+                 "primary_window" => %{
+                   "used_percent" => 10,
+                   "limit_window_seconds" => 18_000,
+                   "window_minutes" => 300
+                 }
+               }
+             }
+             |> Jason.encode!()
+             |> Codex.parse()
+
+    assert {:error, :invalid_reached_type} =
+             %{
+               "rate_limit_reached_type" => %{"type" => "future_state"},
+               "rate_limit" => %{
+                 "primary_window" => %{"used_percent" => 10}
+               }
+             }
+             |> Jason.encode!()
+             |> Codex.parse()
+
+    assert {:error, :invalid_plan} =
+             %{
+               "plan_type" => "private plan details",
+               "rate_limit" => %{
+                 "primary_window" => %{"used_percent" => 10}
+               }
+             }
+             |> Jason.encode!()
+             |> Codex.parse()
+
+    assert {:error, {:invalid_response, :ambiguous_shape}} =
+             %{"rate_limit" => %{}, "rateLimits" => %{}}
+             |> Jason.encode!()
+             |> Codex.parse()
+  end
+
+  test "rejects atom-keyed maps at the JSON boundary" do
+    assert {:error, :invalid_response} = Codex.parse(%{rate_limit: %{}})
   end
 end

--- a/test/llm_proxy/provider_usage/adapters/glm_test.exs
+++ b/test/llm_proxy/provider_usage/adapters/glm_test.exs
@@ -78,8 +78,10 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLMTest do
   end
 
   test "reports authentication, unsupported, and invalid shapes" do
-    assert {:error, :authentication_failed} =
-             %{"code" => 401} |> Jason.encode!() |> GLM.parse()
+    for authentication_failure <- [%{"code" => 401}, %{"code" => 401, "success" => false}] do
+      assert {:error, :authentication_failed} =
+               authentication_failure |> Jason.encode!() |> GLM.parse()
+    end
 
     assert {:error, :unsupported} =
              %{"success" => false} |> Jason.encode!() |> GLM.parse()

--- a/test/llm_proxy/provider_usage/adapters/glm_test.exs
+++ b/test/llm_proxy/provider_usage/adapters/glm_test.exs
@@ -1,0 +1,94 @@
+defmodule LLMProxy.ProviderUsage.Adapters.GLMTest do
+  use ExUnit.Case, async: true
+
+  alias LLMProxy.ProviderUsage.Adapters.GLM
+
+  test "parses current GLM credit windows and reset times" do
+    five_hour_reset = 1_787_176_502_893
+    weekly_reset = 1_787_607_163_997
+
+    assert {:ok, result} =
+             GLM.parse(%{
+               "code" => 200,
+               "success" => true,
+               "data" => %{
+                 "level" => "lite",
+                 "limits" => [
+                   %{
+                     "type" => "CREDIT_LIMIT",
+                     "unit" => 3,
+                     "number" => 5,
+                     "usage" => 2_000,
+                     "currentValue" => 1_653,
+                     "remaining" => 346,
+                     "percentage" => 82,
+                     "nextResetTime" => five_hour_reset
+                   },
+                   %{
+                     "type" => "CREDIT_LIMIT",
+                     "unit" => 6,
+                     "number" => 1,
+                     "percentage" => 45,
+                     "nextResetTime" => weekly_reset
+                   }
+                 ]
+               }
+             })
+
+    assert result.plan == "lite"
+    assert result.availability == :available
+    assert [five_hour, weekly] = result.windows
+
+    assert {five_hour.label, five_hour.used_percent, five_hour.remaining_percent} ==
+             {"5 hour", 82, 18}
+
+    assert five_hour.resets_at ==
+             five_hour_reset
+             |> DateTime.from_unix!(:millisecond)
+             |> DateTime.truncate(:second)
+
+    assert {weekly.label, weekly.used_percent, weekly.remaining_percent} == {"Weekly", 45, 55}
+
+    assert weekly.resets_at ==
+             weekly_reset
+             |> DateTime.from_unix!(:millisecond)
+             |> DateTime.truncate(:second)
+  end
+
+  test "keeps an explicitly absent reset and supports legacy token and tool limits" do
+    assert {:ok, result} =
+             GLM.parse(%{
+               "data" => %{
+                 "limits" => [
+                   %{
+                     "type" => "TOKENS_LIMIT",
+                     "unit" => 3,
+                     "number" => 5,
+                     "percentage" => 100
+                   },
+                   %{
+                     "type" => "TIME_LIMIT",
+                     "percentage" => 12,
+                     "nextResetTime" => 1_800_000_000
+                   }
+                 ]
+               }
+             })
+
+    assert result.availability == :unavailable
+    assert [%{label: "5 hour", resets_at: nil}, %{label: "Monthly tools"}] = result.windows
+  end
+
+  test "reports authentication, unsupported, and invalid shapes" do
+    assert {:error, :authentication_failed} = GLM.parse(%{"code" => 401})
+    assert {:error, :unsupported} = GLM.parse(%{"success" => false})
+    assert {:error, :unsupported} = GLM.parse(%{"data" => %{"limits" => []}})
+
+    assert {:error, :invalid_response} =
+             GLM.parse(%{
+               "data" => %{
+                 "limits" => [%{"type" => "TOKENS_LIMIT", "percentage" => -1}]
+               }
+             })
+  end
+end

--- a/test/llm_proxy/provider_usage/adapters/glm_test.exs
+++ b/test/llm_proxy/provider_usage/adapters/glm_test.exs
@@ -7,34 +7,34 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLMTest do
     five_hour_reset = 1_787_176_502_893
     weekly_reset = 1_787_607_163_997
 
-    assert {:ok, result} =
-             GLM.parse(%{
-               "code" => 200,
-               "success" => true,
-               "data" => %{
-                 "level" => "lite",
-                 "limits" => [
-                   %{
-                     "type" => "CREDIT_LIMIT",
-                     "unit" => 3,
-                     "number" => 5,
-                     "usage" => 2_000,
-                     "currentValue" => 1_653,
-                     "remaining" => 346,
-                     "percentage" => 82,
-                     "nextResetTime" => five_hour_reset
-                   },
-                   %{
-                     "type" => "CREDIT_LIMIT",
-                     "unit" => 6,
-                     "number" => 1,
-                     "percentage" => 45,
-                     "nextResetTime" => weekly_reset
-                   }
-                 ]
-               }
-             })
+    body = %{
+      "code" => 200,
+      "success" => true,
+      "data" => %{
+        "level" => "lite",
+        "limits" => [
+          %{
+            "type" => "CREDIT_LIMIT",
+            "unit" => 3,
+            "number" => 5,
+            "usage" => 2_000,
+            "currentValue" => 1_653,
+            "remaining" => 346,
+            "percentage" => 82,
+            "nextResetTime" => five_hour_reset
+          },
+          %{
+            "type" => "CREDIT_LIMIT",
+            "unit" => 6,
+            "number" => 1,
+            "percentage" => 45,
+            "nextResetTime" => weekly_reset
+          }
+        ]
+      }
+    }
 
+    assert {:ok, result} = body |> Jason.encode!() |> GLM.parse()
     assert result.plan == "lite"
     assert result.availability == :available
     assert [five_hour, weekly] = result.windows
@@ -55,40 +55,77 @@ defmodule LLMProxy.ProviderUsage.Adapters.GLMTest do
              |> DateTime.truncate(:second)
   end
 
-  test "keeps an explicitly absent reset and supports legacy token and tool limits" do
-    assert {:ok, result} =
-             GLM.parse(%{
-               "data" => %{
-                 "limits" => [
-                   %{
-                     "type" => "TOKENS_LIMIT",
-                     "unit" => 3,
-                     "number" => 5,
-                     "percentage" => 100
-                   },
-                   %{
-                     "type" => "TIME_LIMIT",
-                     "percentage" => 12,
-                     "nextResetTime" => 1_800_000_000
-                   }
-                 ]
-               }
-             })
+  test "keeps an explicitly absent reset and supports exact token and tool limits" do
+    body = %{
+      "limits" => [
+        %{
+          "type" => "TOKENS_LIMIT",
+          "unit" => 3,
+          "number" => 5,
+          "percentage" => 100
+        },
+        %{
+          "type" => "TIME_LIMIT",
+          "percentage" => 12,
+          "nextResetTime" => 1_800_000_000
+        }
+      ]
+    }
 
+    assert {:ok, result} = body |> Jason.encode!() |> GLM.parse()
     assert result.availability == :unavailable
     assert [%{label: "5 hour", resets_at: nil}, %{label: "Monthly tools"}] = result.windows
   end
 
   test "reports authentication, unsupported, and invalid shapes" do
-    assert {:error, :authentication_failed} = GLM.parse(%{"code" => 401})
-    assert {:error, :unsupported} = GLM.parse(%{"success" => false})
-    assert {:error, :unsupported} = GLM.parse(%{"data" => %{"limits" => []}})
+    assert {:error, :authentication_failed} =
+             %{"code" => 401} |> Jason.encode!() |> GLM.parse()
+
+    assert {:error, :unsupported} =
+             %{"success" => false} |> Jason.encode!() |> GLM.parse()
+
+    assert {:error, :unsupported} =
+             %{"data" => %{"limits" => []}} |> Jason.encode!() |> GLM.parse()
 
     assert {:error, :invalid_response} =
-             GLM.parse(%{
+             %{
                "data" => %{
                  "limits" => [%{"type" => "TOKENS_LIMIT", "percentage" => -1}]
                }
-             })
+             }
+             |> Jason.encode!()
+             |> GLM.parse()
+  end
+
+  test "rejects malformed entries and unknown limit types instead of dropping them" do
+    assert {:error, {:invalid_response, _reason}} =
+             %{
+               "data" => %{
+                 "limits" => [
+                   %{"type" => "CREDIT_LIMIT", "percentage" => 20},
+                   "malformed"
+                 ]
+               }
+             }
+             |> Jason.encode!()
+             |> GLM.parse()
+
+    assert {:error, :unknown_limit_type} =
+             %{
+               "data" => %{
+                 "limits" => [%{"type" => "FUTURE_LIMIT", "percentage" => 20}]
+               }
+             }
+             |> Jason.encode!()
+             |> GLM.parse()
+
+    assert {:error, {:invalid_response, :unsupported_or_ambiguous_shape}} =
+             %{"data" => %{"limits" => []}, "limits" => []}
+             |> Jason.encode!()
+             |> GLM.parse()
+  end
+
+  test "rejects atom-keyed maps at the JSON boundary" do
+    assert {:error, :invalid_response} = GLM.parse(%{data: %{limits: []}})
   end
 end

--- a/test/llm_proxy/provider_usage/server_test.exs
+++ b/test/llm_proxy/provider_usage/server_test.exs
@@ -1,0 +1,134 @@
+defmodule LLMProxy.ProviderUsage.ServerTest do
+  use ExUnit.Case, async: false
+
+  alias LLMProxy.ProviderUsage.{Server, Snapshot, Window}
+
+  test "serializes refreshes, preserves stale data on errors, and detects age" do
+    parent = self()
+    task_supervisor = unique_name(:tasks)
+    server = unique_name(:server)
+
+    start_supervised!({Task.Supervisor, name: task_supervisor, max_children: 1})
+
+    refresh_fun = fn scope ->
+      send(parent, {:refresh_started, self(), scope})
+
+      receive do
+        {:finish_refresh, result} -> result
+      end
+    end
+
+    start_supervised!(
+      {Server,
+       name: server,
+       task_supervisor: task_supervisor,
+       refresh_fun: refresh_fun,
+       auto_refresh: false,
+       refresh_interval_ms: 60_000,
+       stale_after_ms: 60_000}
+    )
+
+    refreshed_at = ~U[2026-08-23 12:00:00Z]
+    fresh = snapshot(refreshed_at, :fresh, nil, [window()])
+
+    assert {:ok, :started} = Server.refresh_all(server)
+    assert_receive {:refresh_started, first_task, :all}
+    assert {:ok, :already_refreshing} = Server.refresh_account(1, server)
+    send(first_task, {:finish_refresh, [fresh]})
+
+    assert eventually(fn -> Server.snapshots_at(server, refreshed_at) == [fresh] end)
+
+    assert [%{state: :stale, error: "Provider usage data is stale"}] =
+             Server.snapshots_at(server, DateTime.add(refreshed_at, 61, :second))
+
+    failed = snapshot(nil, :error, "Provider usage API timed out", [])
+
+    assert {:ok, :started} = Server.refresh_account(1, server)
+    assert_receive {:refresh_started, second_task, {:account, 1}}
+    send(second_task, {:finish_refresh, [failed]})
+
+    assert eventually(fn ->
+             case Server.snapshots_at(server, refreshed_at) do
+               [%{state: :stale, error: "Provider usage API timed out", windows: [_window]}] ->
+                 true
+
+               _other ->
+                 false
+             end
+           end)
+  end
+
+  test "stops an active refresh task when the cache stops" do
+    parent = self()
+    task_supervisor = unique_name(:cleanup_tasks)
+    server = unique_name(:cleanup_server)
+
+    start_supervised!({Task.Supervisor, name: task_supervisor, max_children: 1})
+
+    refresh_fun = fn scope ->
+      send(parent, {:refresh_started, self(), scope})
+
+      receive do
+        :never -> []
+      end
+    end
+
+    start_supervised!(
+      {Server,
+       name: server,
+       task_supervisor: task_supervisor,
+       refresh_fun: refresh_fun,
+       auto_refresh: true,
+       refresh_interval_ms: 60_000,
+       stale_after_ms: 120_000}
+    )
+
+    assert_receive {:refresh_started, task, :all}, 1_500
+    monitor = Process.monitor(task)
+
+    assert :ok = stop_supervised(Server)
+    assert_receive {:DOWN, ^monitor, :process, ^task, _reason}, 1_000
+  end
+
+  defp snapshot(refreshed_at, state, error, windows) do
+    %Snapshot{
+      token_id: 1,
+      provider_label: "OpenAI Codex",
+      account_label: "Account #1",
+      availability: if(state == :error, do: :unknown, else: :available),
+      state: state,
+      windows: windows,
+      refreshed_at: refreshed_at,
+      attempted_at: ~U[2026-08-23 12:00:00Z],
+      error: error
+    }
+  end
+
+  defp window do
+    %Window{
+      label: "5 hour",
+      used_percent: 40,
+      remaining_percent: 60,
+      resets_at: ~U[2026-08-23 14:00:00Z],
+      duration_seconds: 18_000
+    }
+  end
+
+  defp eventually(fun, attempts \\ 100) do
+    cond do
+      fun.() ->
+        true
+
+      attempts == 0 ->
+        false
+
+      true ->
+        Process.sleep(10)
+        eventually(fun, attempts - 1)
+    end
+  end
+
+  defp unique_name(prefix) do
+    String.to_atom("#{prefix}_#{System.unique_integer([:positive])}")
+  end
+end

--- a/test/llm_proxy/provider_usage/server_test.exs
+++ b/test/llm_proxy/provider_usage/server_test.exs
@@ -58,6 +58,58 @@ defmodule LLMProxy.ProviderUsage.ServerTest do
            end)
   end
 
+  test "rejects malformed, duplicate, and out-of-scope refresh results atomically" do
+    parent = self()
+    task_supervisor = unique_name(:strict_tasks)
+    server = unique_name(:strict_server)
+
+    start_supervised!({Task.Supervisor, name: task_supervisor, max_children: 1})
+
+    refresh_fun = fn scope ->
+      send(parent, {:refresh_started, self(), scope})
+
+      receive do
+        {:finish_refresh, result} -> result
+      end
+    end
+
+    start_supervised!(
+      {Server,
+       name: server,
+       task_supervisor: task_supervisor,
+       refresh_fun: refresh_fun,
+       auto_refresh: false,
+       stale_after_ms: 60_000}
+    )
+
+    at = ~U[2026-08-23 12:00:00Z]
+    fresh = snapshot(at, :fresh, nil, [window()])
+
+    assert {:ok, :started} = Server.refresh_all(server)
+    assert_receive {:refresh_started, seed_task, :all}
+    send(seed_task, {:finish_refresh, [fresh]})
+    assert eventually(fn -> Server.snapshots_at(server, at) == [fresh] end)
+
+    assert {:ok, :started} = Server.refresh_account(1, server)
+    assert_receive {:refresh_started, wrong_scope_task, {:account, 1}}
+    send(wrong_scope_task, {:finish_refresh, [snapshot(at, :fresh, nil, [window()], 2)]})
+
+    assert eventually(fn ->
+             match?(
+               [%{token_id: 1, state: :stale, error: "Provider usage refresh failed"}],
+               Server.snapshots_at(server, at)
+             )
+           end)
+
+    assert {:ok, :started} = Server.refresh_all(server)
+    assert_receive {:refresh_started, duplicate_task, :all}
+    send(duplicate_task, {:finish_refresh, [fresh, fresh]})
+
+    assert eventually(fn ->
+             match?([%{token_id: 1, state: :stale}], Server.snapshots_at(server, at))
+           end)
+  end
+
   test "stops an active refresh task when the cache stops" do
     parent = self()
     task_supervisor = unique_name(:cleanup_tasks)
@@ -90,9 +142,9 @@ defmodule LLMProxy.ProviderUsage.ServerTest do
     assert_receive {:DOWN, ^monitor, :process, ^task, _reason}, 1_000
   end
 
-  defp snapshot(refreshed_at, state, error, windows) do
+  defp snapshot(refreshed_at, state, error, windows, token_id \\ 1) do
     %Snapshot{
-      token_id: 1,
+      token_id: token_id,
       provider_label: "OpenAI Codex",
       account_label: "Account #1",
       availability: if(state == :error, do: :unknown, else: :available),

--- a/test/llm_proxy/provider_usage_test.exs
+++ b/test/llm_proxy/provider_usage_test.exs
@@ -174,4 +174,37 @@ defmodule LLMProxy.ProviderUsageTest do
     assert [%{config_error: "Codex usage base URL is not a valid HTTPS URL"}] =
              Source.accounts()
   end
+
+  test "does not send credentials for per-token endpoint overrides" do
+    ReqTest.stub(UsageStub, fn _conn ->
+      flunk("usage request must not be sent")
+    end)
+
+    assert {:ok, token} =
+             Storage.add_token("glm-pool", "api-key", "glm-api-secret", %{
+               proxy: "https://gateway.example/v1"
+             })
+
+    assert {:error, :unsupported} =
+             LLMProxy.ProviderUsage.refresh_account(Integer.to_string(token.id))
+
+    assert [snapshot] = Loader.refresh({:account, token.id})
+    assert snapshot.state == :error
+
+    assert snapshot.error ==
+             "Provider usage is unavailable for tokens with endpoint overrides"
+  end
+
+  test "rejects oversized provider responses before JSON decoding" do
+    ReqTest.stub(UsageStub, fn conn ->
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, ~s({"padding":"#{String.duplicate("x", 256_001)}"}))
+    end)
+
+    assert {:ok, token} = Storage.add_token("glm-pool", "api-key", "glm-api-secret")
+    assert [snapshot] = Loader.refresh({:account, token.id})
+    assert snapshot.state == :error
+    assert snapshot.error == "Provider returned invalid usage data"
+  end
 end

--- a/test/llm_proxy/provider_usage_test.exs
+++ b/test/llm_proxy/provider_usage_test.exs
@@ -1,0 +1,177 @@
+defmodule LLMProxy.ProviderUsageTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+
+  alias LLMProxy.Provider.TokenCodec.AESGCM
+  alias LLMProxy.ProviderUsage.{Loader, Source}
+  alias LLMProxy.Storage
+  alias LLMProxy.TestSupport
+  alias Req.Test, as: ReqTest
+
+  @codec_key Base.encode64(:binary.copy(<<7>>, 32))
+
+  defmodule UsageStub do
+  end
+
+  setup do
+    TestSupport.checkout_repo()
+    TestSupport.clear_provider_tokens()
+
+    saved =
+      Map.new([:providers, :provider_token_codec, :req_plug], fn key ->
+        {key, Application.fetch_env(:llm_proxy, key)}
+      end)
+
+    Application.put_env(
+      :llm_proxy,
+      :provider_token_codec,
+      {AESGCM, active_key_id: "usage", keys: %{"usage" => @codec_key}}
+    )
+
+    Application.put_env(:llm_proxy, :req_plug, {ReqTest, UsageStub})
+
+    Application.put_env(:llm_proxy, :providers, %{
+      "glm-main" => %{
+        adapter: "zai_coding_plan",
+        base_url: "https://api.z.ai/api/coding/paas/v4",
+        token_pool: "glm-pool"
+      }
+    })
+
+    on_exit(fn ->
+      Enum.each(saved, fn
+        {key, {:ok, value}} -> Application.put_env(:llm_proxy, key, value)
+        {key, :error} -> Application.delete_env(:llm_proxy, key)
+      end)
+    end)
+
+    :ok
+  end
+
+  test "loads encrypted Codex and GLM credentials but returns only redacted state" do
+    ReqTest.stub(UsageStub, fn conn ->
+      case conn.request_path do
+        "/backend-api/wham/usage" ->
+          assert get_req_header(conn, "authorization") == ["Bearer codex-access-secret"]
+          assert get_req_header(conn, "chatgpt-account-id") == ["account-private-id"]
+
+          ReqTest.json(conn, %{
+            "rate_limit" => %{
+              "allowed" => true,
+              "primary_window" => %{
+                "used_percent" => 25,
+                "limit_window_seconds" => 18_000,
+                "reset_at" => 1_800_000_000
+              }
+            }
+          })
+
+        "/api/monitor/usage/quota/limit" ->
+          assert get_req_header(conn, "authorization") == ["glm-api-secret"]
+          send_resp(conn, 401, ~s({"code":401}))
+
+        "/api/monitor/usage" ->
+          assert get_req_header(conn, "authorization") == ["glm-api-secret"]
+
+          ReqTest.json(conn, %{
+            "code" => 200,
+            "success" => true,
+            "data" => %{
+              "limits" => [
+                %{
+                  "type" => "CREDIT_LIMIT",
+                  "unit" => 3,
+                  "number" => 5,
+                  "percentage" => 40,
+                  "nextResetTime" => 1_800_000_000_000
+                }
+              ]
+            }
+          })
+      end
+    end)
+
+    assert {:ok, codex} =
+             Storage.add_token("openai-codex", "oauth", "codex-access-secret", %{
+               account_id: "account-private-id",
+               label: "owner@example.com"
+             })
+
+    assert {:ok, glm} =
+             Storage.add_token("glm-pool", "api-key", "glm-api-secret", %{label: "prod-east"})
+
+    refute codex.token == "codex-access-secret"
+    refute glm.token == "glm-api-secret"
+
+    sources = Source.accounts()
+    assert Enum.map(sources, & &1.token_id) == [codex.id, glm.id]
+    assert Source.supported_account?(codex.id)
+    assert hd(sources).usage_paths == ["/backend-api/wham/usage"]
+
+    source_text = inspect(sources)
+    refute source_text =~ "codex-access-secret"
+    refute source_text =~ "glm-api-secret"
+    refute source_text =~ "account-private-id"
+    refute source_text =~ "owner@example.com"
+
+    assert [codex_snapshot, glm_snapshot] = Loader.refresh(:all)
+    assert codex_snapshot.account_label == "Account ##{codex.id}"
+    assert codex_snapshot.state == :fresh
+    assert codex_snapshot.availability == :available
+    assert [%{used_percent: 25, remaining_percent: 75}] = codex_snapshot.windows
+
+    assert glm_snapshot.account_label == "p***t · ##{glm.id}"
+    assert glm_snapshot.state == :fresh
+    assert [%{used_percent: 40, remaining_percent: 60}] = glm_snapshot.windows
+
+    snapshot_text = inspect([codex_snapshot, glm_snapshot])
+    refute snapshot_text =~ "codex-access-secret"
+    refute snapshot_text =~ "glm-api-secret"
+    refute snapshot_text =~ "account-private-id"
+  end
+
+  test "keeps provider response details out of error state" do
+    ReqTest.stub(UsageStub, fn conn ->
+      send_resp(conn, 500, "glm-api-secret account-private-id")
+    end)
+
+    assert {:ok, token} =
+             Storage.add_token("glm-pool", "api-key", "glm-api-secret", %{
+               label: "unsafe@example.com"
+             })
+
+    assert [snapshot] = Loader.refresh({:account, token.id})
+    assert snapshot.account_label == "Account ##{token.id}"
+    assert snapshot.state == :error
+    assert snapshot.error == "Provider usage API is unavailable"
+    refute inspect(snapshot) =~ "glm-api-secret"
+    refute inspect(snapshot) =~ "account-private-id"
+  end
+
+  test "uses the first-party Codex path style for default and custom bases" do
+    assert {:ok, _token} = Storage.add_token("openai-codex", "oauth", "access")
+
+    Application.put_env(:llm_proxy, :providers, %{
+      "openai-codex" => %{base_url: "https://chatgpt.com"}
+    })
+
+    assert [%{base_url: "https://chatgpt.com/backend-api"} = source] = Source.accounts()
+    assert source.usage_paths == ["/backend-api/wham/usage"]
+    assert source.config_error == nil
+
+    Application.put_env(:llm_proxy, :providers, %{
+      "openai-codex" => %{base_url: "https://codex.example/v2"}
+    })
+
+    assert [source] = Source.accounts()
+    assert source.usage_paths == ["/v2/api/codex/usage"]
+
+    Application.put_env(:llm_proxy, :providers, %{
+      "openai-codex" => %{base_url: "http://codex.example"}
+    })
+
+    assert [%{config_error: "Codex usage base URL is not a valid HTTPS URL"}] =
+             Source.accounts()
+  end
+end

--- a/test/llm_proxy/safe_rpc_test.exs
+++ b/test/llm_proxy/safe_rpc_test.exs
@@ -56,6 +56,20 @@ if Code.ensure_loaded?(Incant) do
       for atom <- ["compact", "density", "options", "select", "safe_rpc_reply"] do
         assert atom in atoms
       end
+
+      assert {:ok, %{"columns" => columns, "rows" => rows}} =
+               LLMProxy.Admin.run_widget("provider_usage", "usage_windows", %{}, %{})
+
+      assert "provider" in columns
+      assert "account" in columns
+      assert is_list(rows)
+
+      refute Enum.any?(rows, fn row ->
+               Enum.any?(
+                 ~w(token access_token refresh_token account_id cookie),
+                 &Map.has_key?(row, &1)
+               )
+             end)
     end
 
     test "runs LLMProxy model and status operations" do


### PR DESCRIPTION
## Summary

Operators can see each OpenAI Codex or GLM Coding Plan account's live usage windows in Incant. The dashboard reports used and remaining capacity, reset time, availability, refresh time, and clear stale or error states. It reads provider quota data and does not estimate quota from local requests.

The tracker keeps provider-specific requests behind adapter boundaries. OpenAI Codex and GLM wire payloads are decoded through typed `JSONCodec` structs with strict string-keyed JSON contracts. Known provider shapes are selected explicitly; malformed nested values, unknown limit types, ambiguous shapes, invalid plan values, duplicate refresh IDs, and out-of-scope account results fail closed rather than being coerced, filtered, or silently overwritten.

Credentials use `LLMProxy.Provider.TokenCodec` and are decoded only for a qualified provider request. Public snapshots contain masked local labels, percentages, times, and fixed safe error text. They do not contain access tokens, refresh tokens, cookies, upstream account IDs, provider payloads, or codec errors. Tokens with per-token endpoint overrides are reported as unsupported without sending their credentials.

A supervised cache runs one sequential refresh task. Manual refresh returns before network I/O completes. Automatic refresh defaults to five minutes and is limited to one minute through one hour. Requests use HTTPS, finite deadlines, no redirects, no automatic retries, and a 256,000-byte response ceiling before JSON decoding. A failed refresh keeps the last good window and marks it stale.

Standalone non-secret settings use strict TOML:

```toml
[provider_usage]
auto_refresh = true
refresh_interval_ms = 300000
request_timeout_ms = 10000
stale_after_ms = 600000
```

Library hosts use equivalent `.exs` application configuration. Provider-specific `usage_adapter`, `usage_auth_scheme`, and `usage_paths` values remain data-only provider configuration. Both modes validate exact values and one through three distinct absolute origin paths.

## Dependencies

None. Provider-token codec PR #10 and fill-first token selection PR #19 are merged upstream. Current `master` was merged additively into this branch.

## Validation

- Focused configuration, provider-usage, Incant, SafeRPC, JSONCodec-boundary, response-limit, and strict-result tests passed.
- `mix ci`: 461 passed, 9 opt-in tests excluded.
- Credential-empty `mix integration`: 5 skipped, no live calls.
- Credential-empty `mix e2e`: 1 local E2E passed, 3 provider tests skipped.
- Format, warnings-as-errors compilation, Credo, Dialyzer, ExDNA, architecture, and smell checks passed.
- Documentation generated successfully with the pre-existing hidden `ConcurrencyLimiter.Lease` reference warning.
- Provider requests used mock replies. No live Codex or GLM credential was used.
