### PR TITLE
feat(tokens): add fill-first selection policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ### Added
 
+- Provider-token pools support affinity or fill-first selection. Fill-first
+  orders healthy tokens within the existing OAuth-first/API-key-fallback
+  boundary by persisted non-negative priority and stable token ID.
 - An optional public-model allowlist keeps HTTP discovery, setup helpers,
   SafeRPC status, and request admission aligned. Standalone deployments
   configure visible aliases through `catalog.public_models` in strict TOML;
@@ -53,6 +56,8 @@
 
 ### Migration
 
+- Existing provider tokens receive priority `0`; indexed DuckDB tables rebuild
+  the provider/kind index while adding or removing the priority column.
 - Existing API keys remain enabled when lifecycle state is added.
 - Existing trace-enabled keys retain content capture. Other existing keys stop
   automatic message and cache capture after migration. Operators must define

--- a/guides/features/providers-and-routing.md
+++ b/guides/features/providers-and-routing.md
@@ -76,13 +76,15 @@ LLM_PROXY_PROVIDER_KEYS='{"example-production":["secret-a","secret-b"]}'
 
 Persisted provider tokens remain the runtime source after seeding. A token record can override the provider base URL through its `proxy` field, but that should be reserved for intentional per-token gateways; normal endpoints belong in provider configuration.
 
-Credential pools use stable user affinity by default. Library applications set
-`token_selection_strategy: :fill_first` in Elixir configuration. Standalone releases set
-`token_selection_strategy = "fill_first"` in the `[routing]` TOML table. Fill-first selection
-uses the highest-priority healthy token until it enters cooldown, then continues in descending
-priority order. Higher integer `priority` values are selected first, and token ID breaks ties.
-Disabled and cooling-down tokens are skipped. A recovered token returns to its configured place
-without changing the priority order.
+Credential pools use stable user affinity by default. Library hosts can set
+`token_selection_strategy: :fill_first`; standalone releases use
+`provider_tokens.selection_strategy = "fill_first"` in TOML. Fill-first keeps
+the existing OAuth-first, API-key-fallback boundary and orders healthy tokens
+within each credential kind by descending non-negative `priority`, then ascending
+token ID. Disabled and cooling-down tokens are skipped. A recovered token
+returns to its configured place without changing the priority order. Incant's
+provider-token edit form exposes only `priority`; credential fields remain
+uneditable and private.
 
 ## Public model aliases
 

--- a/guides/features/providers-and-routing.md
+++ b/guides/features/providers-and-routing.md
@@ -76,6 +76,14 @@ LLM_PROXY_PROVIDER_KEYS='{"example-production":["secret-a","secret-b"]}'
 
 Persisted provider tokens remain the runtime source after seeding. A token record can override the provider base URL through its `proxy` field, but that should be reserved for intentional per-token gateways; normal endpoints belong in provider configuration.
 
+Credential pools use stable user affinity by default. Library applications set
+`token_selection_strategy: :fill_first` in Elixir configuration. Standalone releases set
+`token_selection_strategy = "fill_first"` in the `[routing]` TOML table. Fill-first selection
+uses the highest-priority healthy token until it enters cooldown, then continues in descending
+priority order. Higher integer `priority` values are selected first, and token ID breaks ties.
+Disabled and cooling-down tokens are skipped. A recovered token returns to its configured place
+without changing the priority order.
+
 ## Public model aliases
 
 A readable library configuration uses model aliases and routes:

--- a/guides/introduction/standalone-mode.md
+++ b/guides/introduction/standalone-mode.md
@@ -74,6 +74,7 @@ otlp_endpoint = "http://127.0.0.1:4318"
 
 [provider_tokens]
 allow_plaintext = true
+selection_strategy = "affinity"
 
 [catalog]
 public_models = ["coding"]
@@ -104,6 +105,8 @@ in environment variables or persisted provider-token storage. If the file is abs
 continues with compiled defaults and secret environment configuration. Set
 `provider_tokens.allow_plaintext = false` only after encrypting and verifying all
 stored credentials; with that policy, a missing keyring fails startup.
+`provider_tokens.selection_strategy` accepts `affinity` or `fill_first` and is
+not read from the environment.
 
 See [Providers and Routing](../features/providers-and-routing.md) for the complete model shape.
 

--- a/guides/reference/configuration.cheatmd
+++ b/guides/reference/configuration.cheatmd
@@ -113,6 +113,23 @@ bytes. This keyring is separate from `:master_key`. Writes use only the active
 key ID. Reads accept all key IDs in the keyring. The default plaintext codec is
 for compatibility and does not protect stored credentials.
 
+### Token Selection Strategy
+
+```elixir
+config :llm_proxy, token_selection_strategy: :fill_first
+```
+
+Credential selection within each kind. `:affinity` uses a stable user hash and is the default.
+`:fill_first` uses the highest enabled token `priority`, then the lowest token ID to break ties.
+Cooling-down tokens are skipped without changing this order. Standalone releases use
+`routing.token_selection_strategy` in TOML.
+
+Set priority when adding a provider token. Higher values are selected first:
+
+```elixir
+LLMProxy.Storage.add_token("openai-codex", "oauth", access_token, %{priority: 100})
+```
+
 ### Deployment Failure Threshold
 
 ```elixir
@@ -423,6 +440,7 @@ quackdb_endpoint = "quack:localhost:9494"
 max_retries = 1
 replay_policy = "safe_only"
 provider_connect_timeout_ms = 10000
+token_selection_strategy = "affinity"
 ```
 
 Fallback deployments belong in model routes, not a separate fallback map.

--- a/guides/reference/configuration.cheatmd
+++ b/guides/reference/configuration.cheatmd
@@ -111,7 +111,11 @@ selection_strategy = "fill_first"
 
 This non-secret setting is not read from the environment. Provider-token
 priorities are non-negative integers and can be edited through Incant's
-priority-only form.
+priority-only form. Set an initial priority when adding a token:
+
+```elixir
+LLMProxy.Storage.add_token("openai-codex", "oauth", access_token, %{priority: 100})
+```
 
 ### Provider Token Codec
 
@@ -132,23 +136,6 @@ Codec for provider API keys and OAuth tokens. AES-GCM keys must decode to 32
 bytes. This keyring is separate from `:master_key`. Writes use only the active
 key ID. Reads accept all key IDs in the keyring. The default plaintext codec is
 for compatibility and does not protect stored credentials.
-
-### Token Selection Strategy
-
-```elixir
-config :llm_proxy, token_selection_strategy: :fill_first
-```
-
-Credential selection within each kind. `:affinity` uses a stable user hash and is the default.
-`:fill_first` uses the highest enabled token `priority`, then the lowest token ID to break ties.
-Cooling-down tokens are skipped without changing this order. Standalone releases use
-`routing.token_selection_strategy` in TOML.
-
-Set priority when adding a provider token. Higher values are selected first:
-
-```elixir
-LLMProxy.Storage.add_token("openai-codex", "oauth", access_token, %{priority: 100})
-```
 
 ### Deployment Failure Threshold
 

--- a/guides/reference/configuration.cheatmd
+++ b/guides/reference/configuration.cheatmd
@@ -93,6 +93,26 @@ config :llm_proxy, token_cooldown_ms: :timer.hours(4)
 
 Default credential cooldown after rate limiting. Default: 4 hours.
 
+### Provider Token Selection
+
+```elixir
+config :llm_proxy, token_selection_strategy: :fill_first
+```
+
+`:affinity` is the default and preserves stable user-to-token affinity.
+`:fill_first` selects the highest-priority healthy token within the preferred
+credential kind, breaking ties by token ID. OAuth remains preferred over API
+keys. Standalone TOML:
+
+```toml
+[provider_tokens]
+selection_strategy = "fill_first"
+```
+
+This non-secret setting is not read from the environment. Provider-token
+priorities are non-negative integers and can be edited through Incant's
+priority-only form.
+
 ### Provider Token Codec
 
 ```elixir

--- a/lib/llm_proxy/admin/resources/provider_token.ex
+++ b/lib/llm_proxy/admin/resources/provider_token.ex
@@ -7,6 +7,12 @@ if Code.ensure_loaded?(Incant) do
       repo: LLMProxy.Storage.Repo,
       title: "Provider Tokens"
 
+    changeset({LLMProxy.Admin.Resources.ProviderToken, :priority_changeset})
+
+    form do
+      field(:priority, :number, min: 0, step: 1)
+    end
+
     table density: :compact, default_sort: [provider: :asc] do
       column(:provider, link: true, priority: :primary)
       column(:kind, priority: :secondary)
@@ -39,6 +45,7 @@ if Code.ensure_loaded?(Incant) do
         callback: :enable
       )
 
+      action(:edit, label: "Edit priority")
       action(:remove, confirm: true, destructive: true, callback: :remove)
 
       actions do
@@ -54,6 +61,13 @@ if Code.ensure_loaded?(Incant) do
       end
 
       search([:provider, :label])
+    end
+
+    def priority_changeset(token, attrs) do
+      token
+      |> Ecto.Changeset.cast(attrs, [:priority])
+      |> Ecto.Changeset.validate_required([:priority])
+      |> Ecto.Changeset.validate_number(:priority, greater_than_or_equal_to: 0)
     end
 
     def disable(%{id: id}, _assigns), do: set_enabled(id, false)

--- a/lib/llm_proxy/admin/resources/provider_token.ex
+++ b/lib/llm_proxy/admin/resources/provider_token.ex
@@ -11,6 +11,7 @@ if Code.ensure_loaded?(Incant) do
       column(:provider, link: true, priority: :primary)
       column(:kind, priority: :secondary)
       column(:label, priority: :primary)
+      column(:priority, priority: :secondary)
 
       column(:enabled,
         as: :boolean,

--- a/lib/llm_proxy/config.ex
+++ b/lib/llm_proxy/config.ex
@@ -186,6 +186,17 @@ defmodule LLMProxy.Config do
   def token_cooldown_ms,
     do: Application.get_env(:llm_proxy, :token_cooldown_ms, @default_token_cooldown_ms)
 
+  def token_selection_strategy do
+    case Application.get_env(:llm_proxy, :token_selection_strategy, :affinity) do
+      strategy when strategy in [:affinity, :fill_first] ->
+        strategy
+
+      value ->
+        raise ArgumentError,
+              ":token_selection_strategy must be :affinity or :fill_first, got: #{inspect(value)}"
+    end
+  end
+
   def deployment_failure_threshold,
     do:
       Application.get_env(

--- a/lib/llm_proxy/config/toml.ex
+++ b/lib/llm_proxy/config/toml.ex
@@ -16,8 +16,8 @@ defmodule LLMProxy.Config.TOML do
   @top_level_keys ~w(catalog models provider_tokens providers routing server storage telemetry)
   @server_keys ~w(body_limit_bytes port public_url rpc_socket)
   @storage_keys ~w(database quackdb_endpoint quackdb_uri)
-  @routing_keys ~w(max_retries provider_connect_timeout_ms replay_policy token_selection_strategy)
-  @provider_token_keys ~w(allow_plaintext)
+  @routing_keys ~w(max_retries provider_connect_timeout_ms replay_policy)
+  @provider_token_keys ~w(allow_plaintext selection_strategy)
   @telemetry_keys ~w(otlp_endpoint)
   @catalog_keys ~w(models public_models)
 
@@ -133,10 +133,6 @@ defmodule LLMProxy.Config.TOML do
     |> put_if_present(:max_retries, non_negative_integer(routing, "max_retries"))
     |> put_if_present(:replay_policy, replay_policy(routing["replay_policy"]))
     |> put_if_present(
-      :token_selection_strategy,
-      token_selection_strategy(routing["token_selection_strategy"])
-    )
-    |> put_if_present(
       :provider_connect_timeout_ms,
       positive_integer(routing, "provider_connect_timeout_ms")
     )
@@ -152,15 +148,6 @@ defmodule LLMProxy.Config.TOML do
     raise ArgumentError, "routing.replay_policy must be safe_only or allow_uncertain"
   end
 
-  defp token_selection_strategy(nil), do: nil
-  defp token_selection_strategy("affinity"), do: :affinity
-  defp token_selection_strategy("fill_first"), do: :fill_first
-
-  defp token_selection_strategy(_strategy) do
-    raise ArgumentError,
-          "routing.token_selection_strategy must be affinity or fill_first"
-  end
-
   defp provider_tokens(nil), do: []
 
   defp provider_tokens(%{} = provider_tokens) do
@@ -171,10 +158,23 @@ defmodule LLMProxy.Config.TOML do
       :provider_token_allow_plaintext,
       optional_boolean(provider_tokens, "allow_plaintext")
     )
+    |> put_if_present(
+      :token_selection_strategy,
+      token_selection_strategy(provider_tokens["selection_strategy"])
+    )
   end
 
   defp provider_tokens(_provider_tokens) do
     raise ArgumentError, "provider_tokens must be a TOML table"
+  end
+
+  defp token_selection_strategy(nil), do: nil
+  defp token_selection_strategy("affinity"), do: :affinity
+  defp token_selection_strategy("fill_first"), do: :fill_first
+
+  defp token_selection_strategy(_strategy) do
+    raise ArgumentError,
+          "provider_tokens.selection_strategy must be affinity or fill_first"
   end
 
   defp telemetry(nil), do: []

--- a/lib/llm_proxy/config/toml.ex
+++ b/lib/llm_proxy/config/toml.ex
@@ -16,7 +16,7 @@ defmodule LLMProxy.Config.TOML do
   @top_level_keys ~w(catalog models provider_tokens providers routing server storage telemetry)
   @server_keys ~w(body_limit_bytes port public_url rpc_socket)
   @storage_keys ~w(database quackdb_endpoint quackdb_uri)
-  @routing_keys ~w(max_retries provider_connect_timeout_ms replay_policy)
+  @routing_keys ~w(max_retries provider_connect_timeout_ms replay_policy token_selection_strategy)
   @provider_token_keys ~w(allow_plaintext)
   @telemetry_keys ~w(otlp_endpoint)
   @catalog_keys ~w(models public_models)
@@ -133,6 +133,10 @@ defmodule LLMProxy.Config.TOML do
     |> put_if_present(:max_retries, non_negative_integer(routing, "max_retries"))
     |> put_if_present(:replay_policy, replay_policy(routing["replay_policy"]))
     |> put_if_present(
+      :token_selection_strategy,
+      token_selection_strategy(routing["token_selection_strategy"])
+    )
+    |> put_if_present(
       :provider_connect_timeout_ms,
       positive_integer(routing, "provider_connect_timeout_ms")
     )
@@ -146,6 +150,15 @@ defmodule LLMProxy.Config.TOML do
 
   defp replay_policy(_policy) do
     raise ArgumentError, "routing.replay_policy must be safe_only or allow_uncertain"
+  end
+
+  defp token_selection_strategy(nil), do: nil
+  defp token_selection_strategy("affinity"), do: :affinity
+  defp token_selection_strategy("fill_first"), do: :fill_first
+
+  defp token_selection_strategy(_strategy) do
+    raise ArgumentError,
+          "routing.token_selection_strategy must be affinity or fill_first"
   end
 
   defp provider_tokens(nil), do: []

--- a/lib/llm_proxy/schemas/provider_token.ex
+++ b/lib/llm_proxy/schemas/provider_token.ex
@@ -17,6 +17,7 @@ defmodule LLMProxy.Schemas.ProviderToken do
           refresh_token: String.t() | nil,
           expires_at: DateTime.t() | nil,
           account_id: String.t() | nil,
+          priority: integer(),
           enabled: boolean(),
           added_at: DateTime.t() | nil
         }
@@ -30,6 +31,7 @@ defmodule LLMProxy.Schemas.ProviderToken do
     field(:refresh_token, :string)
     field(:expires_at, :utc_datetime)
     field(:account_id, :string)
+    field(:priority, :integer, default: 0)
     field(:enabled, :boolean, default: true)
     field(:added_at, :utc_datetime)
   end
@@ -45,11 +47,13 @@ defmodule LLMProxy.Schemas.ProviderToken do
       :refresh_token,
       :expires_at,
       :account_id,
+      :priority,
       :enabled,
       :added_at
     ])
     |> validate_required([:provider, :kind, :token, :added_at])
     |> validate_inclusion(:kind, ["api-key", "oauth"])
+    |> validate_number(:priority, greater_than_or_equal_to: 0)
     |> validate_change(:proxy, &validate_proxy/2)
   end
 

--- a/lib/llm_proxy/schemas/provider_token.ex
+++ b/lib/llm_proxy/schemas/provider_token.ex
@@ -17,7 +17,7 @@ defmodule LLMProxy.Schemas.ProviderToken do
           refresh_token: String.t() | nil,
           expires_at: DateTime.t() | nil,
           account_id: String.t() | nil,
-          priority: integer(),
+          priority: non_neg_integer(),
           enabled: boolean(),
           added_at: DateTime.t() | nil
         }
@@ -51,7 +51,7 @@ defmodule LLMProxy.Schemas.ProviderToken do
       :enabled,
       :added_at
     ])
-    |> validate_required([:provider, :kind, :token, :added_at])
+    |> validate_required([:provider, :kind, :token, :priority, :enabled, :added_at])
     |> validate_inclusion(:kind, ["api-key", "oauth"])
     |> validate_number(:priority, greater_than_or_equal_to: 0)
     |> validate_change(:proxy, &validate_proxy/2)

--- a/lib/llm_proxy/token_pool/server.ex
+++ b/lib/llm_proxy/token_pool/server.ex
@@ -2,7 +2,7 @@ defmodule LLMProxy.TokenPool.Server do
   @moduledoc """
   Manages provider tokens with rate-limit cooldowns.
 
-  Picks tokens using FNV-1a hash for cache affinity.
+  Picks tokens using the configured affinity or fill-first strategy.
   Priority: OAuth tokens first, then API keys as fallback.
   """
 
@@ -116,22 +116,20 @@ defmodule LLMProxy.TokenPool.Server do
   end
 
   defp do_pick_by_kind(provider, kind, user_id, state) do
-    tokens = get_enabled_tokens(provider, kind)
+    strategy = LLMProxy.Config.token_selection_strategy()
+    tokens = get_enabled_tokens(provider, kind, strategy)
 
     case tokens do
       [] -> :none
-      tokens -> pick_available(tokens, user_id, state)
+      tokens -> pick_available(tokens, user_id, state, strategy)
     end
   end
 
-  defp pick_available(tokens, user_id, state) do
+  defp pick_available(tokens, user_id, state, strategy) do
     now = System.monotonic_time(:millisecond)
-    start_idx = pick_index(user_id, length(tokens))
 
     tokens
-    |> Stream.cycle()
-    |> Stream.drop(start_idx)
-    |> Stream.take(length(tokens))
+    |> ordered_candidates(strategy, user_id)
     |> Enum.find(fn token ->
       case Map.get(state.cooldowns, token.id) do
         nil -> true
@@ -142,6 +140,18 @@ defmodule LLMProxy.TokenPool.Server do
       nil -> :all_rate_limited
       token -> TokenCodec.for_provider(token)
     end
+  end
+
+  defp ordered_candidates(tokens, :fill_first, _user_id), do: tokens
+
+  defp ordered_candidates(tokens, :affinity, user_id) do
+    pool_size = length(tokens)
+    start_idx = pick_index(user_id, pool_size)
+
+    tokens
+    |> Stream.cycle()
+    |> Stream.drop(start_idx)
+    |> Stream.take(pool_size)
   end
 
   defp pick_index(_user_id, pool_size) when pool_size <= 1, do: 0
@@ -161,10 +171,20 @@ defmodule LLMProxy.TokenPool.Server do
     end)
   end
 
-  defp get_enabled_tokens(provider, kind) do
-    ProviderToken
-    |> where([t], t.provider == ^provider and t.kind == ^kind and t.enabled == true)
-    |> order_by([t], asc: t.id)
-    |> Repo.all()
+  defp get_enabled_tokens(provider, kind, :affinity),
+    do: query_enabled_tokens(provider, kind) |> order_by([t], asc: t.id) |> Repo.all()
+
+  defp get_enabled_tokens(provider, kind, :fill_first),
+    do:
+      query_enabled_tokens(provider, kind)
+      |> order_by([t], desc: t.priority, asc: t.id)
+      |> Repo.all()
+
+  defp query_enabled_tokens(provider, kind) do
+    where(
+      ProviderToken,
+      [t],
+      t.provider == ^provider and t.kind == ^kind and t.enabled == true
+    )
   end
 end

--- a/priv/repo/migrations/20260824000001_add_priority_to_provider_tokens.exs
+++ b/priv/repo/migrations/20260824000001_add_priority_to_provider_tokens.exs
@@ -1,9 +1,25 @@
 defmodule LLMProxy.Repo.Migrations.AddPriorityToProviderTokens do
   use Ecto.Migration
 
-  def change do
+  @disable_ddl_transaction true
+
+  def up do
+    drop(index(:provider_tokens, [:provider, :kind]))
+
     alter table(:provider_tokens) do
       add(:priority, :integer, default: 0, null: false)
     end
+
+    create(index(:provider_tokens, [:provider, :kind]))
+  end
+
+  def down do
+    drop(index(:provider_tokens, [:provider, :kind]))
+
+    alter table(:provider_tokens) do
+      remove(:priority)
+    end
+
+    create(index(:provider_tokens, [:provider, :kind]))
   end
 end

--- a/priv/repo/migrations/20260824000001_add_priority_to_provider_tokens.exs
+++ b/priv/repo/migrations/20260824000001_add_priority_to_provider_tokens.exs
@@ -1,0 +1,9 @@
+defmodule LLMProxy.Repo.Migrations.AddPriorityToProviderTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table(:provider_tokens) do
+      add(:priority, :integer, default: 0, null: false)
+    end
+  end
+end

--- a/test/llm_proxy/admin/resources/provider_token_test.exs
+++ b/test/llm_proxy/admin/resources/provider_token_test.exs
@@ -12,6 +12,25 @@ if Code.ensure_loaded?(Incant) do
       LLMProxy.TestSupport.checkout_repo()
     end
 
+    test "edits only provider-token priority" do
+      {:ok, token} =
+        Storage.add_token("openai", "api-key", "priority-admin-token", %{priority: 10})
+
+      resource = Incant.metadata(ProviderToken)
+
+      assert Enum.map(Incant.Forms.fields(resource), & &1.name) == [:priority]
+      assert Enum.any?(resource.table.actions, &(&1.name == :edit))
+
+      assert {:ok, "Record updated", updated} =
+               Incant.Live.FormState.save(:edit, resource, token, %{
+                 "priority" => "42",
+                 "token" => "must-not-replace-token"
+               })
+
+      assert updated.priority == 42
+      assert updated.token == token.token
+    end
+
     test "enables, disables, and removes provider tokens" do
       {:ok, token} = Storage.add_token("openai", "api-key", "admin-token")
       id = to_string(token.id)

--- a/test/llm_proxy/admin/resources/provider_token_test.exs
+++ b/test/llm_proxy/admin/resources/provider_token_test.exs
@@ -5,6 +5,7 @@ if Code.ensure_loaded?(Incant) do
     @moduletag :incant
 
     alias Incant.ActionResult
+    alias Incant.Live.FormState
     alias LLMProxy.Admin.Resources.ProviderToken
     alias LLMProxy.Storage
 
@@ -22,7 +23,7 @@ if Code.ensure_loaded?(Incant) do
       assert Enum.any?(resource.table.actions, &(&1.name == :edit))
 
       assert {:ok, "Record updated", updated} =
-               Incant.Live.FormState.save(:edit, resource, token, %{
+               FormState.save(:edit, resource, token, %{
                  "priority" => "42",
                  "token" => "must-not-replace-token"
                })

--- a/test/llm_proxy/config/toml_test.exs
+++ b/test/llm_proxy/config/toml_test.exs
@@ -25,6 +25,7 @@ defmodule LLMProxy.Config.TOMLTest do
 
     [provider_tokens]
     allow_plaintext = false
+    selection_strategy = "fill_first"
 
     [telemetry]
     otlp_endpoint = "http://127.0.0.1:4318"
@@ -60,6 +61,7 @@ defmodule LLMProxy.Config.TOMLTest do
     assert llm_proxy[:provider_connect_timeout_ms] == 15_000
     assert llm_proxy[:token_selection_strategy] == :fill_first
     refute llm_proxy[:provider_token_allow_plaintext]
+    assert llm_proxy[:token_selection_strategy] == :fill_first
 
     assert llm_proxy[:quackdb_server][:database] == "/var/lib/llm-proxy/main.duckdb"
     assert llm_proxy[:quackdb_server][:endpoint] == "quack:localhost:9494"
@@ -118,6 +120,10 @@ defmodule LLMProxy.Config.TOMLTest do
 
     assert_raise ArgumentError, ~r/provider_tokens contains unsupported configuration keys/, fn ->
       TOML.decode(~s([provider_tokens]\nkeys = "must-not-live-in-toml"))
+    end
+
+    assert_raise ArgumentError, ~r/selection_strategy must be affinity or fill_first/, fn ->
+      TOML.decode(~s([provider_tokens]\nselection_strategy = "random"))
     end
   end
 

--- a/test/llm_proxy/config/toml_test.exs
+++ b/test/llm_proxy/config/toml_test.exs
@@ -21,7 +21,6 @@ defmodule LLMProxy.Config.TOMLTest do
     max_retries = 2
     replay_policy = "allow_uncertain"
     provider_connect_timeout_ms = 15000
-    token_selection_strategy = "fill_first"
 
     [provider_tokens]
     allow_plaintext = false
@@ -59,7 +58,6 @@ defmodule LLMProxy.Config.TOMLTest do
     assert llm_proxy[:max_retries] == 2
     assert llm_proxy[:replay_policy] == :allow_uncertain
     assert llm_proxy[:provider_connect_timeout_ms] == 15_000
-    assert llm_proxy[:token_selection_strategy] == :fill_first
     refute llm_proxy[:provider_token_allow_plaintext]
     assert llm_proxy[:token_selection_strategy] == :fill_first
 
@@ -142,10 +140,6 @@ defmodule LLMProxy.Config.TOMLTest do
 
     assert_raise ArgumentError, ~r/replay_policy must be safe_only or allow_uncertain/, fn ->
       TOML.decode(~s([routing]\nreplay_policy = "always"))
-    end
-
-    assert_raise ArgumentError, ~r/token_selection_strategy must be affinity or fill_first/, fn ->
-      TOML.decode(~s([routing]\ntoken_selection_strategy = "random"))
     end
 
     assert_raise ArgumentError, ~r/otlp_endpoint must be an absolute HTTP/, fn ->

--- a/test/llm_proxy/config/toml_test.exs
+++ b/test/llm_proxy/config/toml_test.exs
@@ -21,6 +21,7 @@ defmodule LLMProxy.Config.TOMLTest do
     max_retries = 2
     replay_policy = "allow_uncertain"
     provider_connect_timeout_ms = 15000
+    token_selection_strategy = "fill_first"
 
     [provider_tokens]
     allow_plaintext = false
@@ -57,6 +58,7 @@ defmodule LLMProxy.Config.TOMLTest do
     assert llm_proxy[:max_retries] == 2
     assert llm_proxy[:replay_policy] == :allow_uncertain
     assert llm_proxy[:provider_connect_timeout_ms] == 15_000
+    assert llm_proxy[:token_selection_strategy] == :fill_first
     refute llm_proxy[:provider_token_allow_plaintext]
 
     assert llm_proxy[:quackdb_server][:database] == "/var/lib/llm-proxy/main.duckdb"
@@ -134,6 +136,10 @@ defmodule LLMProxy.Config.TOMLTest do
 
     assert_raise ArgumentError, ~r/replay_policy must be safe_only or allow_uncertain/, fn ->
       TOML.decode(~s([routing]\nreplay_policy = "always"))
+    end
+
+    assert_raise ArgumentError, ~r/token_selection_strategy must be affinity or fill_first/, fn ->
+      TOML.decode(~s([routing]\ntoken_selection_strategy = "random"))
     end
 
     assert_raise ArgumentError, ~r/otlp_endpoint must be an absolute HTTP/, fn ->

--- a/test/llm_proxy/config_test.exs
+++ b/test/llm_proxy/config_test.exs
@@ -23,6 +23,8 @@ defmodule LLMProxy.ConfigTest do
     original_provider_token_allow_plaintext =
       Application.fetch_env(:llm_proxy, :provider_token_allow_plaintext)
 
+    original_token_selection = Application.get_env(:llm_proxy, :token_selection_strategy)
+
     on_exit(fn ->
       restore_env(:providers, original_providers)
       restore_env(:catalog, original_catalog)
@@ -40,6 +42,8 @@ defmodule LLMProxy.ConfigTest do
         :provider_token_allow_plaintext,
         original_provider_token_allow_plaintext
       )
+
+      restore_env(:token_selection_strategy, original_token_selection)
     end)
 
     :ok
@@ -144,6 +148,19 @@ defmodule LLMProxy.ConfigTest do
     })
 
     assert Config.provider_value("openrouter", :http_referer) == "https://override.example"
+  end
+
+  test "configures provider token selection" do
+    assert Config.token_selection_strategy() == :affinity
+
+    Application.put_env(:llm_proxy, :token_selection_strategy, :fill_first)
+    assert Config.token_selection_strategy() == :fill_first
+
+    Application.put_env(:llm_proxy, :token_selection_strategy, :random)
+
+    assert_raise ArgumentError, ~r/must be :affinity or :fill_first/, fn ->
+      Config.token_selection_strategy()
+    end
   end
 
   test "normalizes readable provider config" do

--- a/test/llm_proxy/config_test.exs
+++ b/test/llm_proxy/config_test.exs
@@ -24,8 +24,6 @@ defmodule LLMProxy.ConfigTest do
     original_provider_token_allow_plaintext =
       Application.fetch_env(:llm_proxy, :provider_token_allow_plaintext)
 
-    original_token_selection = Application.get_env(:llm_proxy, :token_selection_strategy)
-
     on_exit(fn ->
       restore_env(:providers, original_providers)
       restore_env(:catalog, original_catalog)
@@ -44,8 +42,6 @@ defmodule LLMProxy.ConfigTest do
         :provider_token_allow_plaintext,
         original_provider_token_allow_plaintext
       )
-
-      restore_env(:token_selection_strategy, original_token_selection)
     end)
 
     :ok
@@ -164,19 +160,6 @@ defmodule LLMProxy.ConfigTest do
     })
 
     assert Config.provider_value("openrouter", :http_referer) == "https://override.example"
-  end
-
-  test "configures provider token selection" do
-    assert Config.token_selection_strategy() == :affinity
-
-    Application.put_env(:llm_proxy, :token_selection_strategy, :fill_first)
-    assert Config.token_selection_strategy() == :fill_first
-
-    Application.put_env(:llm_proxy, :token_selection_strategy, :random)
-
-    assert_raise ArgumentError, ~r/must be :affinity or :fill_first/, fn ->
-      Config.token_selection_strategy()
-    end
   end
 
   test "normalizes readable provider config" do

--- a/test/llm_proxy/config_test.exs
+++ b/test/llm_proxy/config_test.exs
@@ -16,6 +16,7 @@ defmodule LLMProxy.ConfigTest do
     original_max_retries = Application.get_env(:llm_proxy, :max_retries)
     original_replay_policy = Application.get_env(:llm_proxy, :replay_policy)
     original_public_models = Application.get_env(:llm_proxy, :public_models)
+    original_token_selection = Application.get_env(:llm_proxy, :token_selection_strategy)
     original_public_url = Application.get_env(:llm_proxy, :public_url)
     original_provider_token_codec = Application.fetch_env(:llm_proxy, :provider_token_codec)
     original_provider_token_keyring = Application.fetch_env(:llm_proxy, :provider_token_keyring)
@@ -34,6 +35,7 @@ defmodule LLMProxy.ConfigTest do
       restore_env(:max_retries, original_max_retries)
       restore_env(:replay_policy, original_replay_policy)
       restore_env(:public_models, original_public_models)
+      restore_env(:token_selection_strategy, original_token_selection)
       restore_env(:public_url, original_public_url)
       restore_fetched_env(:provider_token_codec, original_provider_token_codec)
       restore_fetched_env(:provider_token_keyring, original_provider_token_keyring)
@@ -56,6 +58,20 @@ defmodule LLMProxy.ConfigTest do
     for invalid <- [[""], [" "], [nil], "model-a"] do
       Application.put_env(:llm_proxy, :public_models, invalid)
       assert_raise ArgumentError, fn -> Config.public_models() end
+    end
+  end
+
+  test "validates the token selection strategy" do
+    Application.delete_env(:llm_proxy, :token_selection_strategy)
+    assert Config.token_selection_strategy() == :affinity
+
+    Application.put_env(:llm_proxy, :token_selection_strategy, :fill_first)
+    assert Config.token_selection_strategy() == :fill_first
+
+    Application.put_env(:llm_proxy, :token_selection_strategy, :random)
+
+    assert_raise ArgumentError, ~r/must be :affinity or :fill_first/, fn ->
+      Config.token_selection_strategy()
     end
   end
 

--- a/test/llm_proxy/storage_test.exs
+++ b/test/llm_proxy/storage_test.exs
@@ -356,6 +356,11 @@ defmodule LLMProxy.StorageTest do
                Storage.add_token("openai", "api-key", "tok", %{priority: -1})
 
       assert changeset.errors[:priority]
+
+      assert {:error, changeset} =
+               Storage.add_token("openai", "api-key", "tok", %{priority: nil})
+
+      assert changeset.errors[:priority]
     end
   end
 

--- a/test/llm_proxy/storage_test.exs
+++ b/test/llm_proxy/storage_test.exs
@@ -315,6 +315,7 @@ defmodule LLMProxy.StorageTest do
 
       assert token.provider == "anthropic"
       assert token.kind == "oauth"
+      assert token.priority == 0
       assert token.enabled == true
 
       tokens = Storage.get_tokens("anthropic", "oauth")
@@ -350,6 +351,11 @@ defmodule LLMProxy.StorageTest do
                Storage.add_token("openai", "api-key", "tok", %{proxy: "file:///etc/passwd"})
 
       assert changeset.errors[:proxy]
+
+      assert {:error, changeset} =
+               Storage.add_token("openai", "api-key", "tok", %{priority: -1})
+
+      assert changeset.errors[:priority]
     end
   end
 

--- a/test/llm_proxy/token_pool/server_test.exs
+++ b/test/llm_proxy/token_pool/server_test.exs
@@ -6,10 +6,15 @@ defmodule LLMProxy.TokenPool.ServerTest do
   alias LLMProxy.TokenPool.Server
 
   setup do
+    original_strategy = Application.get_env(:llm_proxy, :token_selection_strategy)
+
     TestSupport.checkout_repo()
     :ok = TestSupport.allow_token_pool()
     TestSupport.clear_provider_tokens()
     Server.clear_rate_limits()
+
+    on_exit(fn -> restore_env(:token_selection_strategy, original_strategy) end)
+
     :ok
   end
 
@@ -63,4 +68,57 @@ defmodule LLMProxy.TokenPool.ServerTest do
     assert {:ok, picked_api_key} = Server.pick_token_by_kind("anthropic", "api-key", "user-1")
     assert picked_api_key.id == api_key.id
   end
+
+  test "affinity remains the default and preserves ID-based pool order" do
+    {:ok, first} = Storage.add_token("openai-codex", "oauth", "first", %{priority: 10})
+
+    {:ok, _higher_priority} =
+      Storage.add_token("openai-codex", "oauth", "second", %{priority: 20})
+
+    assert {:ok, picked} = Server.pick_token("openai-codex", "user-1")
+    assert picked.id == first.id
+  end
+
+  test "fill-first picks the highest-priority enabled token deterministically" do
+    Application.put_env(:llm_proxy, :token_selection_strategy, :fill_first)
+
+    {:ok, lower_priority} =
+      Storage.add_token("openai-codex", "oauth", "lower-priority", %{priority: 10})
+
+    {:ok, higher_priority} =
+      Storage.add_token("openai-codex", "oauth", "higher-priority", %{priority: 20})
+
+    {:ok, same_priority} =
+      Storage.add_token("openai-codex", "oauth", "same-priority", %{priority: 20})
+
+    {:ok, disabled} =
+      Storage.add_token("openai-codex", "oauth", "disabled", %{priority: 30, enabled: false})
+
+    assert {:ok, picked} = Server.pick_token("openai-codex", "user-1")
+    assert picked.id == higher_priority.id
+    refute picked.id in [lower_priority.id, same_priority.id, disabled.id]
+
+    assert {:ok, same_pick} = Server.pick_token("openai-codex", "another-user")
+    assert same_pick.id == higher_priority.id
+  end
+
+  test "fill-first fails over during cooldown and restores priority after recovery" do
+    Application.put_env(:llm_proxy, :token_selection_strategy, :fill_first)
+
+    {:ok, primary} = Storage.add_token("openai-codex", "oauth", "primary", %{priority: 20})
+    {:ok, fallback} = Storage.add_token("openai-codex", "oauth", "fallback", %{priority: 10})
+
+    Server.mark_rate_limited(primary, 25)
+
+    assert {:ok, picked} = Server.pick_token("openai-codex", "user-1")
+    assert picked.id == fallback.id
+
+    Process.sleep(30)
+
+    assert {:ok, recovered} = Server.pick_token("openai-codex", "user-1")
+    assert recovered.id == primary.id
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:llm_proxy, key)
+  defp restore_env(key, value), do: Application.put_env(:llm_proxy, key, value)
 end


### PR DESCRIPTION
## Summary

Add a configurable provider-token selection policy. Stable user affinity remains the default. The new fill-first policy uses the highest-priority healthy token before moving to the next token.

Each provider token has a non-negative persisted `priority`. Within each credential kind, fill-first orders tokens by descending priority and then stable database ID. It skips disabled or cooling-down tokens and returns to a higher-priority token when its cooldown ends. The existing OAuth-first, API-key-fallback boundary remains unchanged.

Incant exposes a priority-only edit form. Its changeset ignores credential fields, so API keys, OAuth tokens, refresh tokens, and proxies are not editable through that form.

Library applications configure `token_selection_strategy: :fill_first` in `.exs`. Standalone releases use strict TOML:

```toml
[provider_tokens]
selection_strategy = "fill_first"
```

This non-secret setting is not read from the environment.

Fixes #14.

## Dependencies

None. This branch is based on current `master` and does not include PR #12 or PR #23.

## Validation

- focused configuration, TOML, storage, admin-form, migration, and token-pool tests passed
- fresh SQLite migration and rollback-compatible DuckDB 1.5.5 DDL sequence passed
- `mix ci`: 438 passed, 9 opt-in tests excluded
- credential-empty `mix integration`: 5 skipped, no live calls
- credential-empty `mix e2e`: 1 local E2E passed, 3 provider tests skipped
- documentation generated successfully with the pre-existing hidden `ConcurrencyLimiter.Lease` reference warning
- `git diff --check`: passed

## Post-deploy validation

- Apply the priority migration before serving requests.
- Confirm the configured strategy is accepted at startup.
- Confirm fill-first uses the highest-priority healthy token within the preferred credential kind and returns to it after cooldown.
- Confirm the Incant edit form exposes only priority.
- Roll back behavior by setting `provider_tokens.selection_strategy = "affinity"`; no data rollback is required.
