### PR TITLE
refactor: move standalone runtime config to TOML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Standalone non-secret runtime settings now come from TOML instead of
+  environment variables. `PORT`, `PUBLIC_URL`, `DATABASE_PATH`, `QUACKDB_URI`,
+  `QUACKDB_ENDPOINT`, `LLM_PROXY_RPC_SOCKET`, `LLM_PROXY_BODY_LIMIT_BYTES`,
+  `LLM_PROXY_PROVIDER_CONNECT_TIMEOUT_MS`, `LLM_MAX_RETRIES`,
+  `LLM_FALLBACKS`, and `OTEL_EXPORTER_OTLP_ENDPOINT` are no longer read.
+  Configure the corresponding `[server]`, `[storage]`, `[routing]`,
+  `[telemetry]`, provider, and model-route settings in the standalone TOML file.
+- Standalone `OPENAI_API_KEYS`, `ANTHROPIC_API_KEYS`, `OPENROUTER_API_KEYS`, and
+  `OPENAI_CODEX_TOKENS` bootstrapping has been removed. Seed API-key pools with
+  the secret `LLM_PROXY_PROVIDER_KEYS` JSON object. Provision Codex OAuth through
+  the admin login flow and preserve its stored token rows in backups.
+- Standalone TOML is now strict and rejects unknown sections, unknown keys, and
+  provider credentials. Library mode remains configured through ordinary Elixir
+  application configuration and may source secrets however the host chooses.
+
 ### Added
 
 - Provider API keys and OAuth tokens can use a pluggable at-rest codec with a

--- a/README.md
+++ b/README.md
@@ -128,18 +128,34 @@ See [Library Mode](https://hexdocs.pm/llm_proxy/library-mode.html) for storage, 
 
 The standalone release runs a local HTTP gateway backed by DuckDB through QuackDB. It listens on `127.0.0.1` and is intended to sit behind your reverse proxy or service mesh.
 
-Configure secrets with environment variables:
+Configure only secrets and the optional TOML location through the environment:
 
 ```bash
 export MASTER_KEY="replace-with-a-long-random-key"
-export OPENAI_API_KEYS="sk-..."
-export DATABASE_PATH="/var/lib/llm-proxy/llm_proxy.duckdb"
-export PORT="4000"
+export LLM_PROXY_PROVIDER_KEYS='{"openai":["sk-..."]}'
+export LLM_PROXY_CONFIG_TOML="/etc/llm-proxy/config.toml"
 ```
 
-Configure public providers and model aliases as data in `/etc/llm-proxy/config.toml`:
+Configure standalone runtime settings, public providers, and model aliases as
+data in that TOML file:
 
 ```toml
+[server]
+port = 4000
+public_url = "https://llm.example.com"
+body_limit_bytes = 32000000
+rpc_socket = "/run/llm-proxy/rpc.sock"
+
+[storage]
+database = "/var/lib/llm-proxy/llm_proxy.duckdb"
+quackdb_uri = "http://127.0.0.1:9494"
+quackdb_endpoint = "quack:localhost:9494"
+
+[routing]
+max_retries = 1
+replay_policy = "safe_only"
+provider_connect_timeout_ms = 10000
+
 [providers.openai-primary]
 adapter = "openai"
 base_url = "https://api.openai.com/v1"

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,27 +27,13 @@ config :opentelemetry_exporter,
   otlp_protocol: :http_protobuf
 
 config :release_kit, :artifact,
-  port: 4101,
+  port: 4000,
   health_path: "/health",
-  env_clear: %{
-    "DATABASE_PATH" => "/var/lib/toys/llm-proxy/main.duckdb",
-    "PORT" => "4101",
-    "PUBLIC_URL" => "https://llm.elixir.toys",
-    "LLM_PROXY_PROVIDER_CONNECT_TIMEOUT_MS" => "10000",
-    "LLM_PROXY_RPC_SOCKET" => "/run/toys/llm-proxy/rpc.sock",
-    "QUACKDB_BINARY_CACHE_DIR" => "/var/lib/toys/llm-proxy/duckdb-bin",
-    "QUACKDB_ENDPOINT" => "quack:localhost:9494",
-    "QUACKDB_URI" => "http://127.0.0.1:9494",
-    "RELEASE_DISTRIBUTION" => "none"
-  },
+  env_clear: %{"RELEASE_DISTRIBUTION" => "none"},
   env_secret: [
     "MASTER_KEY",
-    "ANTHROPIC_API_KEYS",
     "LLM_PROXY_PROVIDER_KEYS",
-    "LLM_PROXY_PROVIDER_TOKEN_KEYRING",
-    "OPENAI_API_KEYS",
-    "OPENAI_CODEX_TOKENS",
-    "OPENROUTER_API_KEYS"
+    "LLM_PROXY_PROVIDER_TOKEN_KEYRING"
   ]
 
 import_config "#{config_env()}.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -9,64 +9,47 @@ if config_env() in [:dev, :prod] do
 end
 
 if config_env() == :prod do
-  quackdb_uri = System.get_env("QUACKDB_URI", "http://127.0.0.1:9494")
-
   config :llm_proxy,
     repo: LLMProxy.Storage.Repo.QuackDB,
     ecto_repos: [LLMProxy.Storage.Repo.QuackDB],
-    http: [port: String.to_integer(System.get_env("PORT", "4000"))],
     quackdb_server: [
       name: LLMProxy.QuackDBServer,
       duckdb: :managed,
-      database: System.get_env("DATABASE_PATH", "./llm_proxy.duckdb"),
-      endpoint: System.get_env("QUACKDB_ENDPOINT", "quack:localhost:9494")
+      database: "./llm_proxy.duckdb",
+      endpoint: "quack:localhost:9494"
     ]
 
   config :llm_proxy, LLMProxy.Storage.Repo.QuackDB,
-    uri: quackdb_uri,
+    uri: "http://127.0.0.1:9494",
     priv: "priv/repo"
 end
 
 if config_env() in [:dev, :prod] do
-  case System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT") do
-    endpoint when is_binary(endpoint) and endpoint != "" ->
-      config :opentelemetry, traces_exporter: :otlp
-      config :opentelemetry_exporter, otlp_endpoint: endpoint
-
-    _other ->
-      config :opentelemetry, traces_exporter: :none
-  end
-
-  fallbacks =
-    case System.get_env("LLM_FALLBACKS") do
-      nil -> %{}
-      json -> Jason.decode!(json)
-    end
-
-  public_url = System.get_env("PUBLIC_URL", "")
-
-  body_limit_bytes =
-    case Integer.parse(System.get_env("LLM_PROXY_BODY_LIMIT_BYTES", "32000000")) do
-      {bytes, ""} when bytes > 0 ->
-        bytes
-
-      _other ->
-        raise "LLM_PROXY_BODY_LIMIT_BYTES must be a positive integer"
-    end
-
-  provider_connect_timeout_ms =
-    case Integer.parse(System.get_env("LLM_PROXY_PROVIDER_CONNECT_TIMEOUT_MS", "10000")) do
-      {timeout, ""} when timeout > 0 ->
-        timeout
-
-      _other ->
-        raise "LLM_PROXY_PROVIDER_CONNECT_TIMEOUT_MS must be a positive integer"
-    end
-
   provider_key_seeds =
     case System.get_env("LLM_PROXY_PROVIDER_KEYS") do
-      nil -> %{}
-      json -> Jason.decode!(json)
+      value when value in [nil, ""] ->
+        %{}
+
+      json ->
+        case Jason.decode(json) do
+          {:ok, %{} = seeds} ->
+            valid? =
+              Enum.all?(seeds, fn
+                {pool, tokens} when is_binary(pool) and is_list(tokens) ->
+                  pool != "" and Enum.all?(tokens, &(is_binary(&1) and &1 != ""))
+
+                _entry ->
+                  false
+              end)
+
+            if valid?, do: seeds, else: raise("invalid LLM_PROXY_PROVIDER_KEYS shape")
+
+          {:ok, _other} ->
+            raise "LLM_PROXY_PROVIDER_KEYS must be a JSON object"
+
+          {:error, _reason} ->
+            raise "invalid LLM_PROXY_PROVIDER_KEYS JSON"
+        end
     end
 
   provider_token_keyring =
@@ -84,20 +67,5 @@ if config_env() in [:dev, :prod] do
   config :llm_proxy,
     master_key: System.get_env("MASTER_KEY"),
     provider_token_keyring: provider_token_keyring,
-    provider_key_seeds: provider_key_seeds,
-    public_url: public_url,
-    rpc_socket: System.get_env("LLM_PROXY_RPC_SOCKET"),
-    providers: %{
-      "anthropic" => %{api_keys: System.get_env("ANTHROPIC_API_KEYS", "")},
-      "openai" => %{api_keys: System.get_env("OPENAI_API_KEYS", "")},
-      "openrouter" => %{
-        api_keys: System.get_env("OPENROUTER_API_KEYS", ""),
-        http_referer: public_url
-      },
-      "openai-codex" => %{oauth_tokens: System.get_env("OPENAI_CODEX_TOKENS", "")}
-    },
-    fallbacks: fallbacks,
-    max_retries: String.to_integer(System.get_env("LLM_MAX_RETRIES", "1")),
-    provider_connect_timeout_ms: provider_connect_timeout_ms,
-    body_limit_bytes: body_limit_bytes
+    provider_key_seeds: provider_key_seeds
 end

--- a/guides/deployment/standalone-deployment.md
+++ b/guides/deployment/standalone-deployment.md
@@ -52,7 +52,7 @@ A typical host uses:
 ```text
 /opt/llm-proxy/releases/<release>/    immutable unpacked release
 /opt/llm-proxy/current/               symlink to active release
-/etc/llm-proxy/config.toml            non-secret provider and model data
+/etc/llm-proxy/config.toml            non-secret runtime, provider, and model data
 /var/lib/llm-proxy/llm_proxy.duckdb   persistent database
 /run/llm-proxy/rpc.sock               optional SafeRPC socket
 ```
@@ -61,33 +61,22 @@ Keep the database and runtime directory outside immutable release paths. Do not 
 
 ## Runtime environment
 
-Minimal production variables:
+The standalone environment contains only secrets and the optional TOML locator:
 
 ```bash
 MASTER_KEY="replace-with-a-long-random-key"
-DATABASE_PATH="/var/lib/llm-proxy/llm_proxy.duckdb"
-PORT="4000"
-PUBLIC_URL="https://llm.example.com"
-```
-
-At least one provider pool also needs credentials:
-
-```bash
-OPENAI_API_KEYS="sk-..."
-ANTHROPIC_API_KEYS="sk-ant-..."
-OPENROUTER_API_KEYS="sk-or-..."
-LLM_PROXY_PROVIDER_KEYS='{"custom-production":["secret"]}'
-```
-
-Optional service integration:
-
-```bash
+LLM_PROXY_PROVIDER_KEYS='{"openai":["sk-..."],"custom-production":["secret"]}'
 LLM_PROXY_CONFIG_TOML="/etc/llm-proxy/config.toml"
-LLM_PROXY_RPC_SOCKET="/run/llm-proxy/rpc.sock"
-OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
 ```
 
-See the [Configuration Cheatsheet](../reference/configuration.cheatmd) for all supported variables.
+Add `LLM_PROXY_PROVIDER_TOKEN_KEYRING` when using encrypted provider-token
+storage. Configure the HTTP listener, public URL, database, RPC socket, routing,
+and OTLP endpoint in TOML. Provider-specific API-key and Codex-token environment
+variables are not supported; use named API-key pools and persisted Codex OAuth
+credentials.
+
+See the [Configuration Cheatsheet](../reference/configuration.cheatmd) for the
+complete environment and TOML schema.
 
 ## Migrate before startup
 
@@ -141,7 +130,7 @@ LLMProxy sends SSE comment heartbeats during upstream silence, but every interme
 
 ## Graceful replacement
 
-When `LLM_PROXY_RPC_SOCKET` is configured, release tasks can coordinate drain state through the running service:
+When `server.rpc_socket` is configured in TOML, release tasks can coordinate drain state through the running service:
 
 ```bash
 bin/llm_proxy eval 'LLMProxy.ReleaseTasks.drain_start()'

--- a/guides/features/admin-integration.md
+++ b/guides/features/admin-integration.md
@@ -67,10 +67,11 @@ config :llm_proxy,
   rpc_socket: "/run/llm-proxy/rpc.sock"
 ```
 
-Or in the standalone release:
+Or in standalone TOML:
 
-```bash
-LLM_PROXY_RPC_SOCKET="/run/llm-proxy/rpc.sock"
+```toml
+[server]
+rpc_socket = "/run/llm-proxy/rpc.sock"
 ```
 
 When a socket is configured, `LLMProxy.RPC.AdminServer` serves two operation namespaces:

--- a/guides/features/governance-and-observability.md
+++ b/guides/features/governance-and-observability.md
@@ -201,7 +201,7 @@ llm_proxy.provider.stream
 
 Spans include provider and model attributes plus the LLMProxy trace ID. HTTP, Ecto, and Req integrations are instrumented through their OpenTelemetry packages.
 
-Standalone releases enable OTLP export when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Without it, trace export is disabled.
+Standalone releases enable OTLP export when `telemetry.otlp_endpoint` is set in TOML. Without it, trace export is disabled.
 
 ## Operational admin
 

--- a/guides/introduction/getting-started.md
+++ b/guides/introduction/getting-started.md
@@ -58,14 +58,15 @@ Continue with [Library Mode](library-mode.md).
 
 Choose standalone mode when multiple applications or external clients need one gateway. The bundled release owns HTTP serving, DuckDB storage, provider credentials, and operational state.
 
-A minimal runtime environment is:
+A minimal secret environment is:
 
 ```bash
 export MASTER_KEY="replace-with-a-long-random-key"
-export OPENAI_API_KEYS="sk-..."
-export DATABASE_PATH="./llm_proxy.duckdb"
-export PORT="4000"
+export LLM_PROXY_PROVIDER_KEYS='{"openai":["sk-..."]}'
 ```
+
+Set the port, database, routing policy, and other non-secret runtime values in
+the standalone TOML file described in the next guide.
 
 Continue with [Standalone Mode](standalone-mode.md) and [Standalone Deployment](../deployment/standalone-deployment.md).
 
@@ -96,7 +97,10 @@ to = "openai"
 model = "gpt-4.1-mini"
 ```
 
-Provider credentials are secrets. Put them in runtime environment variables or persisted provider-token storage, never in committed Elixir or TOML files.
+Provider credentials are secrets. In standalone mode, seed API-key pools with
+`LLM_PROXY_PROVIDER_KEYS` or use persisted provider-token storage. Library hosts
+may source credentials through their own runtime `.exs` configuration. Never put
+credentials in committed Elixir or TOML files.
 
 ## Make a request
 

--- a/guides/introduction/standalone-mode.md
+++ b/guides/introduction/standalone-mode.md
@@ -19,42 +19,58 @@ The loopback bind is intentional. Put a reverse proxy, ingress, or service mesh 
 
 ## Secrets and runtime values
 
-Set secrets in the service environment:
+Set only secrets and the optional config-file location in the service
+environment:
 
 ```bash
 MASTER_KEY="replace-with-a-long-random-key"
-OPENAI_API_KEYS="sk-primary,sk-secondary"
-ANTHROPIC_API_KEYS="sk-ant-..."
-OPENROUTER_API_KEYS="sk-or-..."
+LLM_PROXY_PROVIDER_KEYS='{"openai":["sk-primary"],"anthropic":["sk-ant-..."]}'
 LLM_PROXY_PROVIDER_TOKEN_KEYRING='{"active_key_id":"2026-08","keys":{"2026-08":"base64-encoded-32-byte-key"}}'
-DATABASE_PATH="/var/lib/llm-proxy/llm_proxy.duckdb"
-PORT="4000"
-PUBLIC_URL="https://llm.example.com"
+LLM_PROXY_CONFIG_TOML="/etc/llm-proxy/config.toml"
 ```
 
-`MASTER_KEY` is the bootstrap and operator credential. Provider-key variables seed persisted token records at startup. Existing records remain the runtime source after seeding.
+`MASTER_KEY` is the bootstrap and operator credential. `LLM_PROXY_PROVIDER_KEYS`
+seeds API-key pools by pool name. Existing records remain the runtime source
+after seeding. Provision Codex OAuth through the admin login flow rather than an
+environment variable.
 
 The provider-token keyring is separate from `MASTER_KEY`. Store it in the
 service secret manager and back it up separately from the database. Loss of all
 keyring copies makes encrypted provider tokens unrecoverable. Keep prior key IDs
 in the JSON map until all rows are rotated and verified.
 
-For named configuration-driven providers, seed isolated token pools with JSON:
+The same JSON object can seed isolated pools for configuration-driven providers:
 
 ```bash
 LLM_PROXY_PROVIDER_KEYS='{"example-production":["secret-key"]}'
 ```
 
-Never put API keys, OAuth tokens, or proxy credentials in TOML.
+Never put API keys, OAuth tokens, encryption keys, or proxy credentials in TOML.
+The strict TOML loader rejects provider credential fields.
 
 ## Data configuration
 
 The release optionally reads `/etc/llm-proxy/config.toml`. Override that path with `LLM_PROXY_CONFIG_TOML`.
 
 ```toml
+[server]
+port = 4000
+public_url = "https://llm.example.com"
+body_limit_bytes = 32000000
+rpc_socket = "/run/llm-proxy/rpc.sock"
+
+[storage]
+database = "/var/lib/llm-proxy/llm_proxy.duckdb"
+quackdb_uri = "http://127.0.0.1:9494"
+quackdb_endpoint = "quack:localhost:9494"
+
 [routing]
 max_retries = 1
 replay_policy = "safe_only"
+provider_connect_timeout_ms = 10000
+
+[telemetry]
+otlp_endpoint = "http://127.0.0.1:4318"
 
 [provider_tokens]
 allow_plaintext = true
@@ -76,26 +92,22 @@ failure_threshold = 3
 cooldown_ms = 30000
 ```
 
-The TOML loader accepts routing policy, provider-token rollout policy, and
-provider and model data. Secrets remain in environment variables or persisted
-provider-token storage. If the file is absent, startup continues with environment
-and compiled configuration. Set `provider_tokens.allow_plaintext = false` only
-after encrypting and verifying all stored credentials; with that policy, a
-missing keyring fails startup.
+The TOML loader accepts server, storage, routing, telemetry,
+provider-token rollout, provider, and model data. It rejects unknown keys rather
+than silently ignoring misspelled settings. Secrets remain in environment
+variables or persisted provider-token storage. If the file is absent, startup
+continues with compiled defaults and secret environment configuration. Set
+`provider_tokens.allow_plaintext = false` only after encrypting and verifying all
+stored credentials; with that policy, a missing keyring fails startup.
 
 See [Providers and Routing](../features/providers-and-routing.md) for the complete model shape.
 
 ## Storage
 
-Production uses `LLMProxy.Storage.Repo.QuackDB` and a managed QuackDB process backed by the file at `DATABASE_PATH`.
-
-Related settings:
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `DATABASE_PATH` | `./llm_proxy.duckdb` | DuckDB database file |
-| `QUACKDB_URI` | `http://127.0.0.1:9494` | Ecto adapter endpoint |
-| `QUACKDB_ENDPOINT` | `quack:localhost:9494` | Managed QuackDB listener |
+Production uses `LLMProxy.Storage.Repo.QuackDB` and a managed QuackDB process.
+Configure its database path, Ecto URI, and listener endpoint under `[storage]` in
+TOML. Defaults are `./llm_proxy.duckdb`, `http://127.0.0.1:9494`, and
+`quack:localhost:9494` respectively.
 
 Run migrations before starting a new release:
 
@@ -139,16 +151,19 @@ curl http://127.0.0.1:4000/v1/chat/completions \
   }'
 ```
 
-The default authenticated JSON body limit is 32 MB. Set `LLM_PROXY_BODY_LIMIT_BYTES` to a positive integer to change it. Authentication and quota checks run before the body is read and decoded.
+The default authenticated JSON body limit is 32 MB. Set
+`server.body_limit_bytes` to a positive integer to change it. Authentication and
+quota checks run before the body is read and decoded.
 
 Streaming endpoints emit SSE comment heartbeats while an upstream stream is silent. Heartbeats keep connections alive without changing OpenAI or Anthropic event payloads.
 
 ## SafeRPC and admin
 
-Set a Unix socket path to start the SafeRPC server:
+Set `server.rpc_socket` in TOML to start the SafeRPC server:
 
-```bash
-LLM_PROXY_RPC_SOCKET="/run/llm-proxy/rpc.sock"
+```toml
+[server]
+rpc_socket = "/run/llm-proxy/rpc.sock"
 ```
 
 Remote Elixir callers can execute `LLMProxy.chat` through SafeRPC. When Incant is installed, a separate Incant host can also discover and render LLMProxy's admin resources over this socket.
@@ -157,13 +172,15 @@ The public gateway does not mount an admin UI or Incant API. This keeps model tr
 
 ## Observability
 
-Set an OTLP endpoint to export traces:
+Set `telemetry.otlp_endpoint` in TOML to export traces:
 
-```bash
-OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
+```toml
+[telemetry]
+otlp_endpoint = "http://127.0.0.1:4318"
 ```
 
-Without that variable, OpenTelemetry instrumentation remains active but export is disabled.
+Without that setting, OpenTelemetry instrumentation remains active but export is
+disabled.
 
 Every generation receives a trace ID. HTTP responses return it as `x-request-id` and `x-llm-proxy-trace-id`; in-process responses expose `response.trace_id`.
 

--- a/guides/reference/configuration.cheatmd
+++ b/guides/reference/configuration.cheatmd
@@ -1,6 +1,6 @@
 # Configuration
 
-Library mode uses ordinary Elixir application configuration. Standalone mode additionally reads environment variables and optional TOML provider/model data.
+Library mode uses ordinary Elixir application configuration. Standalone mode reads non-secret runtime and routing data from strict TOML, while environment variables are reserved for secrets and the TOML file location.
 
 ## Application Options
 {: .col-2}
@@ -348,48 +348,16 @@ MASTER_KEY=...
 
 Bootstrap/operator credential.
 
-### Port
-
-```text
-PORT=4000
-```
-
-Standalone loopback HTTP port. Default: `4000`.
-
-### Database Path
-
-```text
-DATABASE_PATH=/var/lib/llm-proxy/llm_proxy.duckdb
-```
-
-DuckDB database file. Default: `./llm_proxy.duckdb`.
-
-### Public URL
-
-```text
-PUBLIC_URL=https://llm.example.com
-```
-
-Public URL for setup helpers and provider headers.
-
-### Provider Keys
-
-```text
-OPENAI_API_KEYS=sk-a,sk-b
-ANTHROPIC_API_KEYS=sk-ant-...
-OPENROUTER_API_KEYS=sk-or-...
-OPENAI_CODEX_TOKENS=access|refresh|expires_ms|account
-```
-
-Comma-separated bootstrap credentials.
-
-### Named Provider Keys
+### Provider API-Key Pools
 
 ```text
 LLM_PROXY_PROVIDER_KEYS={"example-production":["secret"]}
 ```
 
-JSON object mapping token-pool names to credential arrays.
+Secret JSON object mapping token-pool names to API-key arrays. Use pool names
+such as `openai`, `anthropic`, or `openrouter` for built-in providers. Codex OAuth
+credentials are provisioned through the admin login flow and persisted in
+provider-token storage.
 
 ### Provider Token Keyring
 
@@ -407,74 +375,51 @@ key ID and reads accept every retained key.
 LLM_PROXY_CONFIG_TOML=/etc/llm-proxy/config.toml
 ```
 
-Provider/model data file. Default: `/etc/llm-proxy/config.toml`.
-
-### RPC Socket
-
-```text
-LLM_PROXY_RPC_SOCKET=/run/llm-proxy/rpc.sock
-```
-
-SafeRPC Unix socket path.
-
-### Body Limit
-
-```text
-LLM_PROXY_BODY_LIMIT_BYTES=32000000
-```
-
-Positive integer byte limit. Default: 32 MB.
-
-### Provider Connection Timeout
-
-```text
-LLM_PROXY_PROVIDER_CONNECT_TIMEOUT_MS=10000
-```
-
-Positive finite WebSocket connection/upgrade deadline in milliseconds. Established OpenAI Codex streams use no default transport receive deadline.
-
-### Fallbacks
-
-```text
-LLM_FALLBACKS={"primary":["secondary"]}
-```
-
-JSON compatibility fallback map.
-
-### Max Retries
-
-```text
-LLM_MAX_RETRIES=1
-```
-
-Compatibility fallback count. Default: `1`.
-
-### QuackDB URI
-
-```text
-QUACKDB_URI=http://127.0.0.1:9494
-```
-
-HTTP URI used by the QuackDB Ecto adapter.
-
-### QuackDB Endpoint
-
-```text
-QUACKDB_ENDPOINT=quack:localhost:9494
-```
-
-Managed QuackDB listener endpoint.
-
-### OTLP Endpoint
-
-```text
-OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
-```
-
-Enables OpenTelemetry OTLP export when set.
+Standalone TOML data file. Default: `/etc/llm-proxy/config.toml`.
 
 ## Standalone TOML
 {: .col-2}
+
+### Server
+
+```toml
+[server]
+port = 4000
+public_url = "https://llm.example.com"
+body_limit_bytes = 32000000
+rpc_socket = "/run/llm-proxy/rpc.sock"
+```
+
+The listener remains bound to loopback. Omit `rpc_socket` to disable SafeRPC.
+
+### Storage
+
+```toml
+[storage]
+database = "/var/lib/llm-proxy/llm_proxy.duckdb"
+quackdb_uri = "http://127.0.0.1:9494"
+quackdb_endpoint = "quack:localhost:9494"
+```
+
+### Routing Runtime
+
+```toml
+[routing]
+max_retries = 1
+replay_policy = "safe_only"
+provider_connect_timeout_ms = 10000
+```
+
+Fallback deployments belong in model routes, not a separate fallback map.
+
+### Telemetry
+
+```toml
+[telemetry]
+otlp_endpoint = "http://127.0.0.1:4318"
+```
+
+Omit the endpoint to keep trace export disabled.
 
 ### Provider Token Rollout
 

--- a/lib/llm_proxy/config.ex
+++ b/lib/llm_proxy/config.ex
@@ -144,10 +144,12 @@ defmodule LLMProxy.Config do
   def provider_config(provider) when is_binary(provider) do
     configured = Application.get_env(:llm_proxy, :providers, %{}) |> normalize_providers()
     name = provider_name(provider)
+    provider_config = Map.get(configured, name, %{})
 
     @default_providers
     |> Map.get(name, %{})
-    |> deep_merge(Map.get(configured, name, %{}))
+    |> deep_merge(provider_config)
+    |> default_openrouter_referer(name, provider_config)
   end
 
   def provider_value(provider, key), do: provider_value(provider, key, nil)
@@ -289,6 +291,16 @@ defmodule LLMProxy.Config do
   end
 
   defp provider_name(provider) when is_binary(provider), do: String.replace(provider, "_", "-")
+
+  defp default_openrouter_referer(config, "openrouter", configured) do
+    if Map.has_key?(configured, :http_referer) do
+      config
+    else
+      Map.put(config, :http_referer, public_url())
+    end
+  end
+
+  defp default_openrouter_referer(config, _name, _configured), do: config
 
   defp deep_merge(left, right) do
     Map.merge(left, right, fn _key, left_value, right_value ->

--- a/lib/llm_proxy/config/provider.ex
+++ b/lib/llm_proxy/config/provider.ex
@@ -1,10 +1,11 @@
 defmodule LLMProxy.Config.Provider do
   @moduledoc """
-  Release config provider for optional standalone LLMProxy TOML config.
+  Release config provider for strict standalone LLMProxy TOML configuration.
 
-  This provider is intended for the standalone OTP release. It is no-op when the
-  configured TOML file is absent, so embedding applications are unaffected and
-  continue to use normal `config :llm_proxy` application configuration.
+  This provider is intended for the standalone OTP release and merges server,
+  storage, routing, telemetry, provider, and model data. It is no-op when the
+  configured TOML file is absent, so embedding applications remain configured
+  through ordinary Elixir application configuration.
   """
 
   @behaviour Config.Provider
@@ -27,7 +28,7 @@ defmodule LLMProxy.Config.Provider do
     path = opts |> Keyword.fetch!(:path) |> resolve_path()
 
     if File.regular?(path) do
-      Config.Reader.merge(config, llm_proxy: load_toml!(path))
+      Config.Reader.merge(config, load_toml!(path))
     else
       config
     end
@@ -44,8 +45,8 @@ defmodule LLMProxy.Config.Provider do
       {:ok, config} ->
         config
 
-      {:error, reason} ->
-        raise ArgumentError, "invalid LLMProxy TOML config #{path}: #{inspect(reason)}"
+      {:error, _reason} ->
+        raise ArgumentError, "invalid LLMProxy TOML config #{path}"
     end
   end
 end

--- a/lib/llm_proxy/config/toml.ex
+++ b/lib/llm_proxy/config/toml.ex
@@ -1,22 +1,56 @@
 defmodule LLMProxy.Config.TOML do
   @moduledoc """
-  TOML decoder for standalone LLMProxy configuration files.
+  Strict TOML decoder for standalone LLMProxy configuration.
 
-  The decoder keeps TOML as data and translates only the supported top-level
-  shapes into ordinary `:llm_proxy` application configuration keys. It does not
-  create atoms from arbitrary TOML keys.
+  The decoder translates a finite data-only schema into ordinary application
+  configuration. It never creates atoms from arbitrary TOML keys and does not
+  accept credentials or encryption keys.
   """
 
   alias LLMProxy.Catalog.Model
+  alias LLMProxy.Storage.Repo.QuackDB
 
-  @type decoded :: [
-          providers: map(),
-          models: [map()],
-          max_retries: non_neg_integer(),
-          replay_policy: :safe_only | :allow_uncertain,
-          provider_token_allow_plaintext: boolean()
-        ]
+  @type decoded :: keyword()
   @type reason :: Toml.reason()
+
+  @top_level_keys ~w(catalog models provider_tokens providers routing server storage telemetry)
+  @server_keys ~w(body_limit_bytes port public_url rpc_socket)
+  @storage_keys ~w(database quackdb_endpoint quackdb_uri)
+  @routing_keys ~w(max_retries provider_connect_timeout_ms replay_policy)
+  @provider_token_keys ~w(allow_plaintext)
+  @telemetry_keys ~w(otlp_endpoint)
+  @catalog_keys ~w(models)
+
+  @provider_keys %{
+    "adapter" => :adapter,
+    "api_version" => :api_version,
+    "base_url" => :base_url,
+    "beta" => :beta,
+    "conversion_defaults" => :conversion_defaults,
+    "http_referer" => :http_referer,
+    "title" => :title,
+    "token_pool" => :token_pool
+  }
+  @conversion_default_keys %{"max_tokens" => :max_tokens}
+  @model_keys %{
+    "hidden" => :hidden,
+    "metadata" => :metadata,
+    "name" => :name,
+    "routes" => :routes,
+    "routing" => :routing
+  }
+  @route_keys %{
+    "cooldown_ms" => :cooldown_ms,
+    "failure_threshold" => :failure_threshold,
+    "metadata" => :metadata,
+    "model" => :model,
+    "order" => :order,
+    "timeout" => :timeout,
+    "timeout_ms" => :timeout_ms,
+    "to" => :to,
+    "token_pool" => :token_pool,
+    "weight" => :weight
+  }
 
   @spec decode(String.t(), keyword()) :: {:ok, decoded()} | {:error, reason()}
   def decode(input, opts \\ []) when is_binary(input) and is_list(opts) do
@@ -33,144 +67,178 @@ defmodule LLMProxy.Config.TOML do
   end
 
   defp normalize(data) when is_map(data) do
-    routing = data["routing"]
-    provider_tokens = data["provider_tokens"]
+    validate_keys!(data, @top_level_keys, "top-level")
+    catalog = catalog(data["catalog"])
+
+    llm_proxy =
+      []
+      |> Keyword.merge(server(data["server"]))
+      |> Keyword.merge(storage(data["storage"]))
+      |> Keyword.merge(routing(data["routing"]))
+      |> Keyword.merge(provider_tokens(data["provider_tokens"]))
+      |> put_if_present(:providers, providers(data["providers"]))
+      |> put_if_present(:models, models(data["models"] || catalog[:models]))
+
+    [llm_proxy: llm_proxy] ++ telemetry(data["telemetry"])
+  end
+
+  defp server(nil), do: []
+
+  defp server(%{} = server) do
+    validate_keys!(server, @server_keys, "server")
 
     []
-    |> put_if_present(:providers, providers(data["providers"]))
-    |> put_if_present(:models, models(data["models"] || get_in(data, ["catalog", "models"])))
-    |> put_if_present(:max_retries, routing_max_retries(routing))
-    |> put_if_present(:replay_policy, routing_replay_policy(routing))
+    |> put_if_present(:http, server_port(server["port"]))
+    |> put_if_present(:public_url, absolute_http_url(server, "public_url"))
+    |> put_if_present(:body_limit_bytes, positive_integer(server, "body_limit_bytes"))
+    |> put_if_present(:rpc_socket, non_empty_string(server, "rpc_socket"))
+  end
+
+  defp server(_server), do: raise(ArgumentError, "server must be a TOML table")
+
+  defp server_port(nil), do: nil
+  defp server_port(port) when is_integer(port) and port > 0 and port <= 65_535, do: [port: port]
+
+  defp server_port(_port),
+    do: raise(ArgumentError, "server.port must be an integer from 1 to 65535")
+
+  defp storage(nil), do: []
+
+  defp storage(%{} = storage) do
+    validate_keys!(storage, @storage_keys, "storage")
+
+    quackdb_server =
+      []
+      |> put_if_present(:database, non_empty_string(storage, "database"))
+      |> put_if_present(:endpoint, non_empty_string(storage, "quackdb_endpoint"))
+
+    repo =
+      []
+      |> put_if_present(:uri, absolute_http_url(storage, "quackdb_uri"))
+
+    []
+    |> put_if_present(:quackdb_server, quackdb_server)
+    |> put_if_present(QuackDB, repo)
+  end
+
+  defp storage(_storage), do: raise(ArgumentError, "storage must be a TOML table")
+
+  defp routing(nil), do: []
+
+  defp routing(%{} = routing) do
+    validate_keys!(routing, @routing_keys, "routing")
+
+    []
+    |> put_if_present(:max_retries, non_negative_integer(routing, "max_retries"))
+    |> put_if_present(:replay_policy, replay_policy(routing["replay_policy"]))
+    |> put_if_present(
+      :provider_connect_timeout_ms,
+      positive_integer(routing, "provider_connect_timeout_ms")
+    )
+  end
+
+  defp routing(_routing), do: raise(ArgumentError, "routing must be a TOML table")
+
+  defp replay_policy(nil), do: nil
+  defp replay_policy("safe_only"), do: :safe_only
+  defp replay_policy("allow_uncertain"), do: :allow_uncertain
+
+  defp replay_policy(_policy) do
+    raise ArgumentError, "routing.replay_policy must be safe_only or allow_uncertain"
+  end
+
+  defp provider_tokens(nil), do: []
+
+  defp provider_tokens(%{} = provider_tokens) do
+    validate_keys!(provider_tokens, @provider_token_keys, "provider_tokens")
+
+    []
     |> put_if_present(
       :provider_token_allow_plaintext,
-      provider_token_allow_plaintext(provider_tokens)
+      optional_boolean(provider_tokens, "allow_plaintext")
     )
-    |> Enum.reverse()
   end
 
-  defp put_if_present(config, _key, nil), do: config
-  defp put_if_present(config, _key, []), do: config
-  defp put_if_present(config, key, value), do: [{key, value} | config]
-
-  defp routing_max_retries(nil), do: nil
-
-  defp routing_max_retries(%{"max_retries" => retries}) when is_integer(retries) and retries >= 0,
-    do: retries
-
-  defp routing_max_retries(%{"max_retries" => retries}) do
-    raise ArgumentError,
-          "routing.max_retries must be a non-negative integer, got: #{inspect(retries)}"
-  end
-
-  defp routing_max_retries(%{}), do: nil
-
-  defp routing_max_retries(routing) do
-    raise ArgumentError, "routing must be a TOML table, got: #{inspect(routing)}"
-  end
-
-  defp routing_replay_policy(nil), do: nil
-  defp routing_replay_policy(%{"replay_policy" => "safe_only"}), do: :safe_only
-  defp routing_replay_policy(%{"replay_policy" => "allow_uncertain"}), do: :allow_uncertain
-
-  defp routing_replay_policy(%{"replay_policy" => policy}) do
-    raise ArgumentError,
-          "routing.replay_policy must be safe_only or allow_uncertain, got: #{inspect(policy)}"
-  end
-
-  defp routing_replay_policy(%{}), do: nil
-
-  defp provider_token_allow_plaintext(nil), do: nil
-
-  defp provider_token_allow_plaintext(%{} = provider_tokens) do
-    case Map.keys(provider_tokens) -- ["allow_plaintext"] do
-      [] -> parse_provider_token_allow_plaintext(provider_tokens["allow_plaintext"])
-      _unknown -> raise ArgumentError, "provider_tokens only supports allow_plaintext"
-    end
-  end
-
-  defp provider_token_allow_plaintext(_provider_tokens) do
+  defp provider_tokens(_provider_tokens) do
     raise ArgumentError, "provider_tokens must be a TOML table"
   end
 
-  defp parse_provider_token_allow_plaintext(nil), do: nil
+  defp telemetry(nil), do: []
 
-  defp parse_provider_token_allow_plaintext(allow_plaintext) when is_boolean(allow_plaintext),
-    do: allow_plaintext
+  defp telemetry(%{} = telemetry) do
+    validate_keys!(telemetry, @telemetry_keys, "telemetry")
 
-  defp parse_provider_token_allow_plaintext(_allow_plaintext) do
-    raise ArgumentError, "provider_tokens.allow_plaintext must be a boolean"
+    case absolute_http_url(telemetry, "otlp_endpoint") do
+      nil ->
+        []
+
+      endpoint ->
+        [
+          opentelemetry: [traces_exporter: :otlp],
+          opentelemetry_exporter: [otlp_endpoint: endpoint]
+        ]
+    end
   end
+
+  defp telemetry(_telemetry), do: raise(ArgumentError, "telemetry must be a TOML table")
+
+  defp catalog(nil), do: []
+
+  defp catalog(%{} = catalog) do
+    validate_keys!(catalog, @catalog_keys, "catalog")
+    put_if_present([], :models, catalog["models"])
+  end
+
+  defp catalog(_catalog), do: raise(ArgumentError, "catalog must be a TOML table")
 
   defp providers(nil), do: nil
 
-  defp providers(providers) when is_map(providers) do
-    Map.new(providers, fn {name, config} -> {name, provider_config(config)} end)
+  defp providers(%{} = providers) do
+    Map.new(providers, fn
+      {name, %{} = config} -> {name, normalize_map(config, @provider_keys, "provider")}
+      {_name, _config} -> raise ArgumentError, "provider configuration must be a TOML table"
+    end)
   end
 
-  defp providers(_providers), do: nil
-
-  defp provider_config(config) when is_map(config), do: normalize_keys(config)
-  defp provider_config(_config), do: %{}
+  defp providers(_providers), do: raise(ArgumentError, "providers must be a TOML table")
 
   defp models(nil), do: nil
   defp models(models) when is_list(models), do: Enum.map(models, &model/1)
-  defp models(_models), do: nil
+  defp models(_models), do: raise(ArgumentError, "models must be an array of TOML tables")
 
-  defp model(model) when is_map(model) do
+  defp model(%{} = model) do
     model
-    |> normalize_keys()
+    |> normalize_map(@model_keys, "model")
     |> normalize_model_values()
     |> Map.update(:routes, [], &routes/1)
   end
 
-  defp model(_model), do: %{}
+  defp model(_model), do: raise(ArgumentError, "model must be a TOML table")
 
   defp routes(routes) when is_list(routes), do: Enum.map(routes, &route/1)
-  defp routes(_routes), do: []
+  defp routes(_routes), do: raise(ArgumentError, "model routes must be an array of TOML tables")
 
-  defp route(route) when is_map(route) do
+  defp route(%{} = route) do
     route
-    |> normalize_keys()
+    |> normalize_map(@route_keys, "route")
     |> normalize_route_values()
   end
 
-  defp route(_route), do: %{}
+  defp route(_route), do: raise(ArgumentError, "route must be a TOML table")
 
-  @known_keys %{
-    "adapter" => :adapter,
-    "api_keys" => :api_keys,
-    "api_version" => :api_version,
-    "base_url" => :base_url,
-    "beta" => :beta,
-    "conversion_defaults" => :conversion_defaults,
-    "cooldown_ms" => :cooldown_ms,
-    "failure_threshold" => :failure_threshold,
-    "hidden" => :hidden,
-    "http_referer" => :http_referer,
-    "max_tokens" => :max_tokens,
-    "metadata" => :metadata,
-    "model" => :model,
-    "name" => :name,
-    "oauth_tokens" => :oauth_tokens,
-    "order" => :order,
-    "routes" => :routes,
-    "routing" => :routing,
-    "timeout" => :timeout,
-    "timeout_ms" => :timeout_ms,
-    "title" => :title,
-    "to" => :to,
-    "token_pool" => :token_pool,
-    "weight" => :weight
-  }
-
-  defp normalize_keys(map) when is_map(map) do
+  defp normalize_map(map, known_keys, section) do
     Map.new(map, fn {key, value} ->
-      normalized_key = normalize_key(key)
+      normalized_key = known_key!(known_keys, key, section)
       {normalized_key, normalize_value(normalized_key, value)}
     end)
   end
 
-  defp normalize_value(:conversion_defaults, value) when is_map(value), do: normalize_keys(value)
+  defp normalize_value(:conversion_defaults, %{} = value),
+    do: normalize_map(value, @conversion_default_keys, "provider conversion_defaults")
+
+  defp normalize_value(:conversion_defaults, _value),
+    do: raise(ArgumentError, "provider conversion_defaults must be a TOML table")
+
   defp normalize_value(_key, value), do: value
 
   defp normalize_model_values(%{routing: routing} = model),
@@ -186,5 +254,71 @@ defmodule LLMProxy.Config.TOML do
 
   defp normalize_route_values(route), do: route
 
-  defp normalize_key(key) when is_binary(key), do: Map.fetch!(@known_keys, key)
+  defp known_key!(known_keys, key, _section) do
+    case Map.fetch(known_keys, key) do
+      {:ok, normalized} -> normalized
+      :error -> raise ArgumentError, "unsupported TOML configuration key"
+    end
+  end
+
+  defp validate_keys!(map, allowed, section) do
+    if Enum.all?(Map.keys(map), &(&1 in allowed)) do
+      :ok
+    else
+      raise ArgumentError, "#{section} contains unsupported configuration keys"
+    end
+  end
+
+  defp non_empty_string(map, key) do
+    case Map.fetch(map, key) do
+      :error -> nil
+      {:ok, value} when is_binary(value) and value != "" -> value
+      {:ok, _value} -> raise ArgumentError, "#{key} must be a non-empty string"
+    end
+  end
+
+  defp positive_integer(map, key) do
+    case Map.fetch(map, key) do
+      :error -> nil
+      {:ok, value} when is_integer(value) and value > 0 -> value
+      {:ok, _value} -> raise ArgumentError, "#{key} must be a positive integer"
+    end
+  end
+
+  defp non_negative_integer(map, key) do
+    case Map.fetch(map, key) do
+      :error -> nil
+      {:ok, value} when is_integer(value) and value >= 0 -> value
+      {:ok, _value} -> raise ArgumentError, "#{key} must be a non-negative integer"
+    end
+  end
+
+  defp optional_boolean(map, key) do
+    case Map.fetch(map, key) do
+      :error -> nil
+      {:ok, value} when is_boolean(value) -> value
+      {:ok, _value} -> raise ArgumentError, "#{key} must be a boolean"
+    end
+  end
+
+  defp absolute_http_url(map, key) do
+    case non_empty_string(map, key) do
+      nil -> nil
+      value -> validate_http_url!(value, key)
+    end
+  end
+
+  defp validate_http_url!(value, key) do
+    case URI.parse(value) do
+      %URI{scheme: scheme, host: host} when scheme in ["http", "https"] and is_binary(host) ->
+        value
+
+      _uri ->
+        raise ArgumentError, "#{key} must be an absolute HTTP(S) URL"
+    end
+  end
+
+  defp put_if_present(config, _key, nil), do: config
+  defp put_if_present(config, _key, []), do: config
+  defp put_if_present(config, key, value), do: Keyword.put(config, key, value)
 end

--- a/lib/llm_proxy/release_tasks.ex
+++ b/lib/llm_proxy/release_tasks.ex
@@ -121,9 +121,7 @@ defmodule LLMProxy.ReleaseTasks do
   end
 
   defp ops_call(op, payload \\ %{}, opts \\ []) do
-    socket =
-      LLMProxy.Config.rpc_socket() || System.get_env("LLM_PROXY_RPC_SOCKET") ||
-        raise "LLM_PROXY_RPC_SOCKET is not configured"
+    socket = LLMProxy.Config.rpc_socket() || raise "LLMProxy RPC socket is not configured"
 
     with :ok <- SafeRPC.Atoms.prepare(LLMProxy.Ops.client_atoms()),
          :ok <- SafeRPC.prepare(socket) do

--- a/test/llm_proxy/config/provider_test.exs
+++ b/test/llm_proxy/config/provider_test.exs
@@ -2,14 +2,26 @@ defmodule LLMProxy.Config.ProviderTest do
   use ExUnit.Case, async: true
 
   alias LLMProxy.Config.Provider
+  alias LLMProxy.Storage.Repo.QuackDB
 
   test "load/2 merges TOML config when file exists" do
     path = tmp_path("llm-proxy-config.toml")
 
     File.write!(path, """
+    [server]
+    port = 4101
+    public_url = "https://llm.example.com"
+
+    [storage]
+    database = "/var/lib/llm-proxy/main.duckdb"
+    quackdb_uri = "http://127.0.0.1:9494"
+
     [routing]
     max_retries = 2
     replay_policy = "safe_only"
+
+    [telemetry]
+    otlp_endpoint = "http://127.0.0.1:4318"
 
     [provider_tokens]
     allow_plaintext = false
@@ -25,7 +37,15 @@ defmodule LLMProxy.Config.ProviderTest do
     model = "gpt-5.3-codex-spark"
     """)
 
-    config = Provider.load([], path: path)
+    initial = [
+      llm_proxy: [
+        http: [ip: {127, 0, 0, 1}, port: 4000],
+        quackdb_server: [name: LLMProxy.QuackDBServer, duckdb: :managed]
+      ],
+      opentelemetry: [span_processor: :batch, traces_exporter: :none]
+    ]
+
+    config = Provider.load(initial, path: path)
 
     assert Keyword.get(config, :llm_proxy)[:providers]["openai-codex"].base_url ==
              "https://chatgpt.com/backend-api"
@@ -33,9 +53,33 @@ defmodule LLMProxy.Config.ProviderTest do
     llm_proxy = Keyword.fetch!(config, :llm_proxy)
 
     assert [%{name: "codex", routes: [%{to: "openai-codex"}]}] = llm_proxy[:models]
+    assert llm_proxy[:http] == [ip: {127, 0, 0, 1}, port: 4101]
+    assert llm_proxy[:public_url] == "https://llm.example.com"
+
+    assert llm_proxy[:quackdb_server] == [
+             name: LLMProxy.QuackDBServer,
+             duckdb: :managed,
+             database: "/var/lib/llm-proxy/main.duckdb"
+           ]
+
+    assert llm_proxy[QuackDB] == [uri: "http://127.0.0.1:9494"]
     assert llm_proxy[:max_retries] == 2
     assert llm_proxy[:replay_policy] == :safe_only
     refute llm_proxy[:provider_token_allow_plaintext]
+    assert config[:opentelemetry] == [span_processor: :batch, traces_exporter: :otlp]
+    assert config[:opentelemetry_exporter] == [otlp_endpoint: "http://127.0.0.1:4318"]
+  end
+
+  test "load/2 reports invalid TOML without echoing file contents" do
+    path = tmp_path("invalid.toml")
+    File.write!(path, ~s([server]\nport = "seeded-secret"))
+
+    error =
+      assert_raise ArgumentError, "server.port must be an integer from 1 to 65535", fn ->
+        Provider.load([], path: path)
+      end
+
+    refute Exception.message(error) =~ "seeded-secret"
   end
 
   test "load/2 is a no-op when file is absent" do

--- a/test/llm_proxy/config/toml_test.exs
+++ b/test/llm_proxy/config/toml_test.exs
@@ -2,12 +2,31 @@ defmodule LLMProxy.Config.TOMLTest do
   use ExUnit.Case, async: true
 
   alias LLMProxy.Config.TOML
+  alias LLMProxy.Storage.Repo.QuackDB
 
-  test "decodes providers and models into application config" do
+  test "decodes the complete standalone configuration into application config" do
     input = """
-    [providers.openai-codex]
-    base_url = "https://chatgpt.com/backend-api"
-    oauth_tokens = "token"
+    [server]
+    port = 4101
+    public_url = "https://llm.example.com"
+    body_limit_bytes = 64000000
+    rpc_socket = "/run/llm-proxy/rpc.sock"
+
+    [storage]
+    database = "/var/lib/llm-proxy/main.duckdb"
+    quackdb_uri = "http://127.0.0.1:9494"
+    quackdb_endpoint = "quack:localhost:9494"
+
+    [routing]
+    max_retries = 2
+    replay_policy = "allow_uncertain"
+    provider_connect_timeout_ms = 15000
+
+    [provider_tokens]
+    allow_plaintext = false
+
+    [telemetry]
+    otlp_endpoint = "http://127.0.0.1:4318"
 
     [providers.configured]
     adapter = "openai"
@@ -18,51 +37,59 @@ defmodule LLMProxy.Config.TOMLTest do
     max_tokens = 4096
 
     [[models]]
-    name = "codex"
-
-    [[models.routes]]
-    to = "openai-codex"
-    model = "gpt-5.3-codex-spark"
-    timeout = 15000
-
-    [[models]]
     name = "fast"
     routing = "lowest_cost"
 
     [[models.routes]]
-    to = "openai"
-    model = "gpt-4o-mini"
+    to = "configured"
+    model = "upstream-model"
+    timeout = 15000
     order = 1
     """
 
-    assert {:ok,
-            [
-              providers: %{
-                "openai-codex" => %{
-                  base_url: "https://chatgpt.com/backend-api",
-                  oauth_tokens: "token"
-                },
-                "anthropic" => %{conversion_defaults: %{max_tokens: 4096}},
-                "configured" => %{
-                  adapter: "openai",
-                  base_url: "https://configured.example/v1",
-                  token_pool: "configured-production"
-                }
-              },
-              models: [
-                %{
-                  name: "codex",
-                  routes: [
-                    %{to: "openai-codex", model: "gpt-5.3-codex-spark", timeout_ms: 15_000}
-                  ]
-                },
-                %{
-                  name: "fast",
-                  routing: :lowest_cost,
-                  routes: [%{to: "openai", model: "gpt-4o-mini", order: 1}]
-                }
-              ]
-            ]} = TOML.decode(input)
+    assert {:ok, config} = TOML.decode(input)
+    llm_proxy = Keyword.fetch!(config, :llm_proxy)
+
+    assert llm_proxy[:http] == [port: 4101]
+    assert llm_proxy[:public_url] == "https://llm.example.com"
+    assert llm_proxy[:body_limit_bytes] == 64_000_000
+    assert llm_proxy[:rpc_socket] == "/run/llm-proxy/rpc.sock"
+    assert llm_proxy[:max_retries] == 2
+    assert llm_proxy[:replay_policy] == :allow_uncertain
+    assert llm_proxy[:provider_connect_timeout_ms] == 15_000
+    refute llm_proxy[:provider_token_allow_plaintext]
+
+    assert llm_proxy[:quackdb_server][:database] == "/var/lib/llm-proxy/main.duckdb"
+    assert llm_proxy[:quackdb_server][:endpoint] == "quack:localhost:9494"
+
+    assert llm_proxy[QuackDB] == [uri: "http://127.0.0.1:9494"]
+
+    assert llm_proxy[:providers] == %{
+             "anthropic" => %{conversion_defaults: %{max_tokens: 4096}},
+             "configured" => %{
+               adapter: "openai",
+               base_url: "https://configured.example/v1",
+               token_pool: "configured-production"
+             }
+           }
+
+    assert llm_proxy[:models] == [
+             %{
+               name: "fast",
+               routing: :lowest_cost,
+               routes: [
+                 %{
+                   to: "configured",
+                   model: "upstream-model",
+                   timeout_ms: 15_000,
+                   order: 1
+                 }
+               ]
+             }
+           ]
+
+    assert config[:opentelemetry] == [traces_exporter: :otlp]
+    assert config[:opentelemetry_exporter] == [otlp_endpoint: "http://127.0.0.1:4318"]
   end
 
   test "supports catalog.models as an alternate TOML nesting" do
@@ -75,47 +102,43 @@ defmodule LLMProxy.Config.TOMLTest do
     model = "gpt-5.3-codex-spark"
     """
 
-    assert {:ok, [models: [%{name: "codex", routes: [%{to: "openai-codex"}]}]]} =
-             TOML.decode(input)
+    assert {:ok, [llm_proxy: config]} = TOML.decode(input)
+
+    assert config[:models] == [
+             %{name: "codex", routes: [%{to: "openai-codex", model: "gpt-5.3-codex-spark"}]}
+           ]
   end
 
-  test "decodes standalone routing policy" do
-    input = """
-    [routing]
-    max_retries = 2
-    replay_policy = "allow_uncertain"
-    """
-
-    assert {:ok, [max_retries: 2, replay_policy: :allow_uncertain]} = TOML.decode(input)
-  end
-
-  test "decodes provider-token rollout policy" do
-    input = """
-    [provider_tokens]
-    allow_plaintext = false
-    """
-
-    assert {:ok, [provider_token_allow_plaintext: false]} = TOML.decode(input)
-
-    assert_raise ArgumentError, ~r/provider_tokens.allow_plaintext must be a boolean/, fn ->
-      TOML.decode(~s([provider_tokens]\nallow_plaintext = "false"))
+  test "rejects credentials and encryption keys in TOML" do
+    assert_raise ArgumentError, ~r/unsupported TOML configuration key/, fn ->
+      TOML.decode(~s([providers.openai]\napi_keys = "must-not-live-in-toml"))
     end
 
-    assert_raise ArgumentError, ~r/provider_tokens only supports allow_plaintext/, fn ->
+    assert_raise ArgumentError, ~r/provider_tokens contains unsupported configuration keys/, fn ->
       TOML.decode(~s([provider_tokens]\nkeys = "must-not-live-in-toml"))
     end
   end
 
-  test "rejects invalid standalone routing policy" do
-    assert_raise ArgumentError, ~r/routing.max_retries must be a non-negative integer/, fn ->
+  test "rejects unknown sections and invalid standalone values" do
+    assert_raise ArgumentError, ~r/top-level contains unsupported configuration keys/, fn ->
+      TOML.decode("[unknown]\nvalue = 1")
+    end
+
+    assert_raise ArgumentError, ~r/server.port must be an integer/, fn ->
+      TOML.decode("[server]\nport = 70000")
+    end
+
+    assert_raise ArgumentError, ~r/max_retries must be a non-negative integer/, fn ->
       TOML.decode("[routing]\nmax_retries = -1")
     end
 
-    assert_raise ArgumentError,
-                 ~r/routing.replay_policy must be safe_only or allow_uncertain/,
-                 fn ->
-                   TOML.decode(~s([routing]\nreplay_policy = "always"))
-                 end
+    assert_raise ArgumentError, ~r/replay_policy must be safe_only or allow_uncertain/, fn ->
+      TOML.decode(~s([routing]\nreplay_policy = "always"))
+    end
+
+    assert_raise ArgumentError, ~r/otlp_endpoint must be an absolute HTTP/, fn ->
+      TOML.decode(~s([telemetry]\notlp_endpoint = "localhost:4318"))
+    end
   end
 
   test "returns TOML parser errors" do

--- a/test/llm_proxy/config_test.exs
+++ b/test/llm_proxy/config_test.exs
@@ -15,6 +15,7 @@ defmodule LLMProxy.ConfigTest do
     original_connect_timeout = Application.get_env(:llm_proxy, :provider_connect_timeout_ms)
     original_max_retries = Application.get_env(:llm_proxy, :max_retries)
     original_replay_policy = Application.get_env(:llm_proxy, :replay_policy)
+    original_public_url = Application.get_env(:llm_proxy, :public_url)
     original_provider_token_codec = Application.fetch_env(:llm_proxy, :provider_token_codec)
     original_provider_token_keyring = Application.fetch_env(:llm_proxy, :provider_token_keyring)
 
@@ -29,6 +30,7 @@ defmodule LLMProxy.ConfigTest do
       restore_env(:provider_connect_timeout_ms, original_connect_timeout)
       restore_env(:max_retries, original_max_retries)
       restore_env(:replay_policy, original_replay_policy)
+      restore_env(:public_url, original_public_url)
       restore_fetched_env(:provider_token_codec, original_provider_token_codec)
       restore_fetched_env(:provider_token_keyring, original_provider_token_keyring)
 
@@ -117,6 +119,19 @@ defmodule LLMProxy.ConfigTest do
              size: 4,
              count: 8
            ]
+  end
+
+  test "uses the standalone public URL as OpenRouter's default referer" do
+    Application.put_env(:llm_proxy, :public_url, "https://llm.example.com")
+    Application.put_env(:llm_proxy, :providers, %{})
+
+    assert Config.provider_value("openrouter", :http_referer) == "https://llm.example.com"
+
+    Application.put_env(:llm_proxy, :providers, %{
+      "openrouter" => %{http_referer: "https://override.example"}
+    })
+
+    assert Config.provider_value("openrouter", :http_referer) == "https://override.example"
   end
 
   test "normalizes readable provider config" do

--- a/test/llm_proxy/release_tasks_test.exs
+++ b/test/llm_proxy/release_tasks_test.exs
@@ -22,7 +22,6 @@ defmodule LLMProxy.ReleaseTasksTest do
 
   setup do
     previous = Application.get_env(:llm_proxy, :rpc_socket)
-    previous_env = System.get_env("LLM_PROXY_RPC_SOCKET")
     previous_codec = Application.fetch_env(:llm_proxy, :provider_token_codec)
 
     on_exit(fn ->
@@ -30,12 +29,6 @@ defmodule LLMProxy.ReleaseTasksTest do
         Application.put_env(:llm_proxy, :rpc_socket, previous)
       else
         Application.delete_env(:llm_proxy, :rpc_socket)
-      end
-
-      if previous_env do
-        System.put_env("LLM_PROXY_RPC_SOCKET", previous_env)
-      else
-        System.delete_env("LLM_PROXY_RPC_SOCKET")
       end
 
       case previous_codec do
@@ -65,22 +58,6 @@ defmodule LLMProxy.ReleaseTasksTest do
     assert :ok = ReleaseTasks.drain_await(100)
     assert :ok = ReleaseTasks.drain_cancel()
     assert %{draining: false} = LLMProxy.Drain.status()
-
-    GenServer.stop(server)
-  end
-
-  test "release tasks use the RPC socket environment in a clean eval-style VM" do
-    socket =
-      Path.join(
-        System.tmp_dir!(),
-        "llm-proxy-release-drain-env-#{System.unique_integer([:positive])}.sock"
-      )
-
-    Application.delete_env(:llm_proxy, :rpc_socket)
-    System.put_env("LLM_PROXY_RPC_SOCKET", socket)
-    {:ok, server} = AdminServer.start_link(socket: socket)
-
-    assert :ok = ReleaseTasks.drain_status()
 
     GenServer.stop(server)
   end


### PR DESCRIPTION
## Summary

- reserve the standalone environment for secrets and the TOML file locator
- move server, storage, routing-runtime, provider-token rollout, and telemetry settings into strict TOML sections
- reject unknown TOML keys and reject provider credentials/encryption keys in TOML
- remove standalone provider-specific credential variables in favor of `LLM_PROXY_PROVIDER_KEYS` and persisted Codex OAuth
- keep library mode on ordinary Elixir application configuration
- document every breaking environment-variable removal in the changelog

## Breaking configuration changes

The standalone release no longer reads:

- `PORT`, `PUBLIC_URL`, or `LLM_PROXY_BODY_LIMIT_BYTES`
- `DATABASE_PATH`, `QUACKDB_URI`, or `QUACKDB_ENDPOINT`
- `LLM_PROXY_RPC_SOCKET`
- `LLM_PROXY_PROVIDER_CONNECT_TIMEOUT_MS`, `LLM_MAX_RETRIES`, or `LLM_FALLBACKS`
- `OTEL_EXPORTER_OTLP_ENDPOINT`
- `OPENAI_API_KEYS`, `ANTHROPIC_API_KEYS`, `OPENROUTER_API_KEYS`, or `OPENAI_CODEX_TOKENS`

Non-secret replacements live under `[server]`, `[storage]`, `[routing]`, `[telemetry]`, providers, and model routes. API-key pools use the secret `LLM_PROXY_PROVIDER_KEYS` JSON object. Codex OAuth uses persisted admin provisioning.

## Verification

- `mix ci`: 422 passed, 8 opt-in tests excluded
- `MIX_ENV=prod mix compile --warnings-as-errors`: passed
- credential-empty `mix integration`: 5 skipped, no live calls
- credential-empty `mix e2e`: 3 skipped, no live calls
- `mix docs`: generated successfully with the pre-existing hidden `ConcurrencyLimiter.Lease` reference warning
- `mix hex.audit`: continues to report the existing Cowlib 2.19.0 advisories
